### PR TITLE
refactor

### DIFF
--- a/cmd/examples/kube/main.go
+++ b/cmd/examples/kube/main.go
@@ -31,6 +31,10 @@ func run() error {
 	}
 
 	dep := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appsv1.SchemeGroupVersion.Identifier(),
+			Kind:       "Deployment",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -53,7 +53,7 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 
 	RegisterGlobalFlags(flagset, &params.GlobalSettings)
 
-	flagset.BoolVar(&params.TestRun, "test-run", false, "test-run executes the underlying wasm and outputs it to stdout but does not apply any resources to the cluster")
+	flagset.BoolVar(&params.SendToStdout, "stdout", false, "execute the underlying wasm and outputs it to stdout but does not apply any resources to the cluster")
 	flagset.BoolVar(&params.SkipDryRun, "skip-dry-run", false, "disables running dry run to resources before applying them")
 	flagset.BoolVar(&params.ForceConflicts, "force-conflicts", false, "force apply changes on field manager conflicts")
 	flagset.BoolVar(&params.CreateCRDs, "create-crds", true, "applies custom resource definitions found in flights")

--- a/cmd/yoke/main_test.go
+++ b/cmd/yoke/main_test.go
@@ -157,7 +157,7 @@ func TestCreateWithWait(t *testing.T) {
 
 	// Expectation split into two to remove flakiness. The context being canceled can trigger errors from different places
 	// either directly within yoke or within client-go, hence we capture the cause and the top level message only
-	require.Contains(t, err.Error(), "release did not become ready within wait period: to rollback use `yoke descent`: failed to get readiness for default.apps.v1.deployment.sample-app")
+	require.Contains(t, err.Error(), "release did not become ready within wait period: to rollback use `yoke descent`: failed to get readiness for default/apps/v1/deployment/sample-app")
 	require.Contains(t, err.Error(), "1ns timeout reached")
 
 	require.NoError(t, mayday())
@@ -178,7 +178,7 @@ func TestFailApplyDryRun(t *testing.T) {
 	require.EqualError(
 		t,
 		TakeOff(background, params),
-		`failed to apply resources: dry run: does-not-exist.apps.v1.deployment.sample-app: namespaces "does-not-exist" not found`,
+		`failed to apply resources: dry run: does-not-exist/apps/v1/deployment/sample-app: namespaces "does-not-exist" not found`,
 	)
 }
 
@@ -205,7 +205,7 @@ func TestReleaseOwnership(t *testing.T) {
 	require.EqualError(
 		t,
 		TakeOff(background, makeParams("bar")),
-		`failed to apply resources: dry run: default.apps.v1.deployment.sample-app: failed to validate resource release: expected release "bar" but resource is already owned by "foo"`,
+		`failed to apply resources: dry run: default/apps/v1/deployment/sample-app: failed to validate resource release: expected release "bar" but resource is already owned by "foo"`,
 	)
 
 	client, err := k8s.NewClientFromKubeConfig(home.Kubeconfig)
@@ -311,7 +311,7 @@ func TestTakeoffWithNamespaceResource(t *testing.T) {
 	require.EqualError(
 		t,
 		TakeOff(background, params(false)),
-		`failed to apply resources: dry run: test-ns-resource.core.v1.configmap.test-cm: namespaces "test-ns-resource" not found`,
+		`failed to apply resources: dry run: test-ns-resource/core/v1/configmap/test-cm: namespaces "test-ns-resource" not found`,
 	)
 
 	require.NoError(t, TakeOff(background, params(true)))
@@ -399,7 +399,7 @@ func TestTakeoffWithCRDResource(t *testing.T) {
 	require.EqualError(
 		t,
 		TakeOff(background, params(false)),
-		`failed to apply resources: dry run: _.stable.example.com.v1.crontab.test: failed to resolve resource: no matches for kind "CronTab" in version "stable.example.com/v1"`,
+		`failed to apply resources: dry run: _/stable.example.com/v1/crontab/test: failed to resolve resource: no matches for kind "CronTab" in version "stable.example.com/v1"`,
 	)
 
 	require.NoError(t, TakeOff(background, params(true)))
@@ -538,7 +538,7 @@ func TestTurbulenceFix(t *testing.T) {
 	)
 
 	require.NoError(t, Turbulence(ctx, TurbulenceParams{GlobalSettings: settings, Release: "foo", Fix: true}))
-	require.Equal(t, "fixed drift for: default.core.v1.configmap.test\n", stderr.String())
+	require.Equal(t, "fixed drift for: default/core/v1/configmap/test\n", stderr.String())
 
 	configmap, err = client.CoreV1().ConfigMaps("default").Get(background, "test", metav1.GetOptions{})
 	require.NoError(t, err)

--- a/internal/revision.go
+++ b/internal/revision.go
@@ -112,7 +112,7 @@ func Canonical(resource *unstructured.Unstructured) string {
 			resource.GetKind(),
 			resource.GetName(),
 		},
-		".",
+		"/",
 	))
 }
 

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -281,13 +281,15 @@ func ExportToFS(dir, release string, resources []*unstructured.Unstructured) err
 		return fmt.Errorf("failed remove previous flight export: %w", err)
 	}
 
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		return fmt.Errorf("failed to create release output directory: %w", err)
-	}
-
 	var errs []error
 	for _, resource := range resources {
 		path := filepath.Join(root, internal.Canonical(resource)+".yaml")
+
+		parent, _ := filepath.Split(path)
+
+		if err := os.MkdirAll(parent, 0o755); err != nil {
+			return fmt.Errorf("failed to create release output directory: %w", err)
+		}
 
 		if err := internal.WriteYAML(path, resource.Object); err != nil {
 			errs = append(errs, err)

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -37,7 +37,7 @@ type FlightParams struct {
 }
 
 type TakeoffParams struct {
-	TestRun          bool
+	SendToStdout     bool
 	SkipDryRun       bool
 	ForceConflicts   bool
 	Release          string
@@ -61,7 +61,7 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) er
 		return fmt.Errorf("failed to evaluate flight: %w", err)
 	}
 
-	if params.TestRun {
+	if params.SendToStdout {
 		_, err = internal.Stdout(ctx).Write(output)
 		return err
 	}


### PR DESCRIPTION
- **yoke: rename takeoff flag test-run to stdout**
- **debug: split wasi execute debugging into two separate calls for compilating and execution**
- **yoke: breaking change: use a forward slash to separate segments in internal canonical representation of resources**
