### PR TITLE
develop

### DIFF
--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -158,7 +158,9 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, logger *slog.Logger) h
 			},
 		}
 
-		if err := commander.Takeoff(r.Context(), params); err != nil && !internal.IsWarning(err) {
+		ctx := internal.WithStderr(r.Context(), io.Discard)
+
+		if err := commander.Takeoff(ctx, params); err != nil && !internal.IsWarning(err) {
 			review.Response.Allowed = false
 			review.Response.Result = &metav1.Status{
 				Status:  metav1.StatusFailure,

--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -131,8 +131,5 @@ func Compile(ctx context.Context, params CompileParams) (mod wazero.CompiledModu
 		err = xerr.MultiErrFrom("", err, runtime.Close(ctx))
 	}()
 
-	// TODO: check if this is needed for compilation? If not remove.
-	wasi_snapshot_preview1.MustInstantiate(ctx, runtime)
-
 	return runtime.CompileModule(ctx, params.Wasm)
 }


### PR DESCRIPTION
- **atc: log desired version in crdconvert endpoint**
- **atc: remove dry-run takeoff log during flight validation**
- **internal/wasi: do not instantiate wasip1 for compiling**
