### PR TITLE
readme: add Homebrew installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,12 @@ From source:
 go install github.com/yokecd/yoke/cmd/yoke@latest
 ```
 
+With Homebrew:
+
+```bash
+brew install yoke
+```
+
 ## Documentation
 
 Official documentation can be found [here](https://yokecd.github.io/docs)


### PR DESCRIPTION
Hello! I recently added yoke to Homebrew in https://github.com/Homebrew/homebrew-core/pull/209295. This PR adds installation instructions via brew to the readme.