### PR TITLE
yoke/takeoff: stream stderr back to user instead of internal buffering on error

### DIFF
--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -94,5 +94,9 @@ func TakeOff(ctx context.Context, params TakeoffParams) error {
 	if err != nil {
 		return err
 	}
+
+	// We want the CLI to stream stderr back to the user instead of buffering.
+	params.TakeoffParams.Flight.Stderr = internal.Stderr(ctx)
+
 	return commander.Takeoff(ctx, params.TakeoffParams)
 }

--- a/pkg/yoke/wasm.go
+++ b/pkg/yoke/wasm.go
@@ -122,6 +122,7 @@ func EvalFlight(ctx context.Context, client *k8s.Client, release string, flight 
 		Module:  flight.Module,
 		Release: release,
 		Stdin:   flight.Input,
+		Stderr:  flight.Stderr,
 		Args:    flight.Args,
 		Env: map[string]string{
 			"YOKE_RELEASE":   release,

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -30,10 +30,15 @@ type FlightParams struct {
 	Path                string
 	Insecure            bool
 	Module              *wasi.Module
-	Input               io.Reader
 	Args                []string
 	Namespace           string
 	CompilationCacheDir string
+
+	// Stderr is the writer that will be exposed to the wasm module as os.Stderr.
+	// If not provided all stderr writes in the wasm module will be buffered instead
+	// and surfaced to the user only on error exit codes.
+	Stderr io.Writer
+	Input  io.Reader
 }
 
 type TakeoffParams struct {


### PR DESCRIPTION
Relates to #92 

Connects flight stderr to user's tty when using the CLI.

Maintains previous behaviour in other contexts like the ATC (Buffered capture of stderr)