### PR TITLE
atc resource validator

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
 
   test:
     cmds:
-      - go test -timeout 10m -p 1 -count 1 -v ./...
+      - go test -timeout 20m -p 1 -count 1 -v ./...
 
   update-tools:
     cmds:

--- a/cmd/atc-installer/installer/run.go
+++ b/cmd/atc-installer/installer/run.go
@@ -375,6 +375,7 @@ func Run(cfg Config) (flight.Stages, error) {
 					{
 						Operations: []admissionregistrationv1.OperationType{
 							admissionregistrationv1.Update,
+							admissionregistrationv1.Delete,
 						},
 						Rule: admissionregistrationv1.Rule{
 							APIGroups:   []string{"*"},

--- a/cmd/atc-installer/installer/run.go
+++ b/cmd/atc-installer/installer/run.go
@@ -360,7 +360,7 @@ func Run(cfg Config) (flight.Stages, error) {
 				MatchConditions: []admissionregistrationv1.MatchCondition{
 					{
 						Name:       "yoke-labeled",
-						Expression: fmt.Sprintf("%q in object.metadata.labels", internal.LabelYokeRelease),
+						Expression: fmt.Sprintf("%q in object.metadata.labels || %q in oldObject.metadata.labels", internal.LabelYokeRelease, internal.LabelYokeRelease),
 					},
 					{
 						Name: "not-atc-service-account",

--- a/cmd/atc-installer/installer/run.go
+++ b/cmd/atc-installer/installer/run.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
+	"github.com/yokecd/yoke/internal"
 	"github.com/yokecd/yoke/pkg/apis/airway/v1alpha1"
 	"github.com/yokecd/yoke/pkg/flight"
 	"github.com/yokecd/yoke/pkg/flight/wasi/k8s"
@@ -243,6 +244,54 @@ func Run(cfg Config) (flight.Stages, error) {
 		},
 	}
 
+	resourceValidation := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: admissionregistrationv1.SchemeGroupVersion.Identifier(),
+			Kind:       "ValidatingWebhookConfiguration",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: flight.Release() + "-resources",
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name: "resources.yoke.cd",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: svc.Namespace,
+						Name:      svc.Name,
+						Path:      ptr.To("/validations/resources"),
+						Port:      &svc.Spec.Ports[0].Port,
+					},
+					CABundle: tls.RootCA,
+				},
+				SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+				AdmissionReviewVersions: []string{"v1"},
+				FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
+				MatchPolicy:             ptr.To(admissionregistrationv1.Exact),
+				MatchConditions: []admissionregistrationv1.MatchCondition{
+					{
+						Name:       "yoke-labeled",
+						Expression: fmt.Sprintf(`%q in object.metadata.labels`, internal.LabelYokeRelease),
+					},
+				},
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Update,
+						},
+
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{"*"},
+							APIVersions: []string{"*"},
+							Resources:   []string{"*"},
+							Scope:       ptr.To(admissionregistrationv1.AllScopes),
+						},
+					},
+				},
+			},
+		},
+	}
+
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -343,6 +392,9 @@ func Run(cfg Config) (flight.Stages, error) {
 			airwayValidation,
 			account,
 			binding,
+		},
+		{
+			resourceValidation,
 		},
 	}, nil
 }

--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -239,6 +239,24 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, logger *slog.Logger) h
 		}
 	})
 
+	mux.HandleFunc("POST /validations/resources", func(w http.ResponseWriter, r *http.Request) {
+		var review admissionv1.AdmissionReview
+		if err := json.NewDecoder(r.Body).Decode(&review); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		fmt.Println(review.Request.Resource.String())
+
+		review.Response = &admissionv1.AdmissionResponse{
+			UID:     review.Request.UID,
+			Allowed: true,
+		}
+		review.Request = nil
+
+		json.NewEncoder(w).Encode(review)
+	})
+
 	mux.HandleFunc("POST /validations/airways.yoke.cd", func(w http.ResponseWriter, r *http.Request) {
 		var review admissionv1.AdmissionReview
 		if err := json.NewDecoder(r.Body).Decode(&review); err != nil {

--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -263,7 +263,7 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, logger *slog.Logger) h
 			return
 		}
 
-		if internal.GetOwner(prev) != internal.GetOwner(next) {
+		if internal.GetOwner(&prev) != internal.GetOwner(&next) {
 			review.Response.Allowed = false
 			review.Response.Result = &metav1.Status{
 				Message: "cannot modify yoke labels",

--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -291,7 +291,7 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 			return
 		}
 
-		if next != nil && ctrl.ResourcesAreEqual(prev, next) {
+		if next != nil && internal.ResourcesAreEqual(prev, next) {
 			addRequestAttrs(r.Context(), slog.String("skipReason", "resources are equal"))
 			return
 		}
@@ -378,7 +378,7 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 
 			internal.RemoveAdditions(desired, next)
 
-			if !ctrl.ResourcesAreEqual(desired, next) {
+			if !internal.ResourcesAreEqual(desired, next) {
 				review.Response.Allowed = false
 				review.Response.Result = &metav1.Status{
 					Message: "cannot modify flight sub-resources",

--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -326,13 +326,13 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 
 		addRequestAttrs(r.Context(), slog.String("airwayMode", string(mode)))
 
+		labels := next.GetLabels()
+		release := labels[internal.LabelYokeRelease]
+		namespace := labels[internal.LabelYokeReleaseNS]
+
 		switch mode {
 		case v1alpha1.AirwayModeStatic:
-			release, err := client.GetRelease(
-				r.Context(),
-				next.GetLabels()[internal.LabelYokeRelease],
-				next.GetLabels()[internal.LabelYokeReleaseNS],
-			)
+			release, err := client.GetRelease(r.Context(), release, namespace)
 			if err != nil {
 				// Handle?
 				return
@@ -375,9 +375,7 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 				// Ownership will always be in the same namespace...
 				// Perhaps support for cluster scope owners needs to be thought of?
 				// Also crossNamespace deployments?
-				//
-				// At best the current implementation is limited to Regular Namespaced Flights.
-				Namespace: next.GetNamespace(),
+				Namespace: namespace,
 				Drift:     true,
 			}
 

--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -252,6 +252,10 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 		review.Response = &admissionv1.AdmissionResponse{
 			UID:     review.Request.UID,
 			Allowed: true,
+			Result: &metav1.Status{
+				Status:  metav1.StatusSuccess,
+				Message: "validation passed",
+			},
 		}
 
 		var prev unstructured.Unstructured
@@ -279,6 +283,11 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 
 		defer func() {
 			review.Request = nil
+			addRequestAttrs(r.Context(), slog.Group(
+				"validation",
+				"allowed", review.Response.Allowed,
+				"details", review.Response.Result.Message,
+			))
 			json.NewEncoder(w).Encode(review)
 		}()
 

--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -322,13 +322,13 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 			return
 		}
 
-		mode := cmp.Or(controller.Mode, v1alpha1.AirwayModeStandard)
-
-		addRequestAttrs(r.Context(), slog.String("airwayMode", string(mode)))
-
 		labels := next.GetLabels()
 		release := labels[internal.LabelYokeRelease]
 		namespace := labels[internal.LabelYokeReleaseNS]
+
+		mode := controller.FlightMode(next.GetName(), namespace)
+
+		addRequestAttrs(r.Context(), slog.String("airwayMode", string(mode)))
 
 		switch mode {
 		case v1alpha1.AirwayModeStatic:

--- a/cmd/atc/internal/testing/Dockerfile.wasmcache
+++ b/cmd/atc/internal/testing/Dockerfile.wasmcache
@@ -10,6 +10,7 @@ COPY . .
 
 RUN \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/flight.v1.wasm ./cmd/atc/internal/testing/apis/backend/v1/flight && \
+  GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/flight.v1.modes.wasm ./cmd/atc/internal/testing/apis/backend/v1/modeFlight && \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/flight.v2.wasm ./cmd/atc/internal/testing/apis/backend/v2/flight && \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/flight.dev.wasm ./cmd/atc/internal/testing/apis/backend/v2/dev && \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/converter.wasm ./cmd/atc/internal/testing/apis/backend/converter && \

--- a/cmd/atc/internal/testing/apis/backend/v1/modeFlight/main.go
+++ b/cmd/atc/internal/testing/apis/backend/v1/modeFlight/main.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"cmp"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	v1 "github.com/yokecd/yoke/cmd/atc/internal/testing/apis/backend/v1"
+	"github.com/yokecd/yoke/pkg/flight"
+	"github.com/yokecd/yoke/pkg/flight/wasi/k8s"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var backend v1.Backend
+	if err := yaml.NewYAMLToJSONDecoder(os.Stdin).Decode(&backend); err != nil && err != io.EOF {
+		return err
+	}
+
+	backend.Spec.ServicePort = cmp.Or(backend.Spec.ServicePort, 3000)
+
+	if backend.Spec.Labels == nil {
+		backend.Spec.Labels = map[string]string{}
+	}
+
+	maps.Copy(backend.Spec.Labels, selector(backend))
+
+	cm, err := createConfigMap(backend)
+	if err != nil {
+		return fmt.Errorf("failed to create configmap: %v", err)
+	}
+
+	// the configmap will allow us to test dynamic modes by overriding replicas via the configmap.
+	if cm != nil {
+		if replicas, err := strconv.Atoi(cm.Data["replicas"]); err == nil && replicas > 0 {
+			backend.Spec.Replicas = int32(replicas)
+		}
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(flight.Resources{
+		cm,
+		createDeployment(backend),
+		createService(backend),
+	})
+}
+
+func createConfigMap(backend v1.Backend) (*corev1.ConfigMap, error) {
+	cm, err := k8s.Lookup[corev1.ConfigMap](k8s.ResourceIdentifier{
+		Name:       backend.Name,
+		Namespace:  backend.Namespace,
+		Kind:       "ConfigMap",
+		ApiVersion: "v1",
+	})
+	if err != nil && !k8s.IsErrNotFound(err) {
+		if errors.Is(err, k8s.ErrorClusterAccessNotGranted) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to lookup configmap: %v", err)
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      backend.Name,
+			Namespace: backend.Namespace,
+		},
+		Data: func() map[string]string {
+			if cm != nil {
+				return cm.Data
+			}
+			return map[string]string{}
+		}(),
+	}, nil
+}
+
+func createDeployment(backend v1.Backend) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appsv1.SchemeGroupVersion.Identifier(),
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      backend.Name,
+			Namespace: backend.Namespace,
+			Labels:    backend.Spec.Labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &backend.Spec.Replicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+			Selector: &metav1.LabelSelector{MatchLabels: selector(backend)},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: backend.Spec.Labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            backend.Name,
+							Image:           backend.Spec.Image,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "PORT",
+									Value: strconv.Itoa(backend.Spec.ServicePort),
+								},
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          backend.Name,
+									Protocol:      corev1.ProtocolTCP,
+									ContainerPort: int32(backend.Spec.ServicePort),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createService(backend v1.Backend) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.Identifier(),
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      backend.Name,
+			Namespace: backend.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: selector(backend),
+			Type: func() corev1.ServiceType {
+				if backend.Spec.NodePort > 0 {
+					return corev1.ServiceTypeNodePort
+				}
+				return corev1.ServiceTypeClusterIP
+			}(),
+			Ports: []corev1.ServicePort{
+				{
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   int32(backend.Spec.NodePort),
+					Port:       80,
+					TargetPort: intstr.FromString(backend.Name),
+				},
+			},
+		},
+	}
+}
+
+func selector(backend v1.Backend) map[string]string {
+	return map[string]string{"app": backend.Name}
+}

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/yokecd/yoke/internal/atc/wasm"
 	"github.com/yokecd/yoke/internal/k8s"
 	"github.com/yokecd/yoke/internal/k8s/ctrl"
-	"github.com/yokecd/yoke/internal/xsync"
 )
 
 func main() {
@@ -73,7 +72,7 @@ func run() (err error) {
 	}
 
 	moduleCache := new(wasm.ModuleCache)
-	controllers := new(xsync.Map[string, *ctrl.Instance])
+	controllers := new(atc.ControllerCache)
 
 	var wg sync.WaitGroup
 	wg.Add(3)

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -1261,10 +1261,13 @@ func TestAirwayModes(t *testing.T) {
 	testBE, err := backendIntf.Get(ctx, "test", metav1.GetOptions{})
 	require.NoError(t, err)
 
-	labels := testBE.GetLabels()
-	labels[flight.AnnotationOverrideMode] = string(v1alpha1.AirwayModeDynamic)
+	annotations := testBE.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[flight.AnnotationOverrideMode] = string(v1alpha1.AirwayModeDynamic)
 
-	testBE.SetLabels(labels)
+	testBE.SetAnnotations(annotations)
 
 	_, err = backendIntf.Update(ctx, testBE, metav1.UpdateOptions{FieldManager: "test"})
 	require.NoError(t, err)

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -972,6 +972,9 @@ func TestFixDriftInterval(t *testing.T) {
 		Wait: 30 * time.Second,
 		Poll: time.Second,
 	}))
+	defer func() {
+		require.NoError(t, commander.Mayday(ctx, "test", "default"))
+	}()
 
 	deploymentIntf := client.Clientset.AppsV1().Deployments("default")
 
@@ -1174,32 +1177,32 @@ func TestAirwayModes(t *testing.T) {
 		Wait: 30 * time.Second,
 		Poll: time.Second,
 	}))
-	// defer func() {
-	// 	require.NoError(t, commander.Mayday(ctx, "modes-airway", ""))
-	//
-	// 	airwayIntf := client.Dynamic.Resource(schema.GroupVersionResource{
-	// 		Group:    "yoke.cd",
-	// 		Version:  "v1alpha1",
-	// 		Resource: "airways",
-	// 	})
-	//
-	// 	testutils.EventuallyNoErrorf(
-	// 		t,
-	// 		func() error {
-	// 			_, err := airwayIntf.Get(ctx, "backends.examples.com", metav1.GetOptions{})
-	// 			if err == nil {
-	// 				return fmt.Errorf("backends.examples.com has not been removed")
-	// 			}
-	// 			if !kerrors.IsNotFound(err) {
-	// 				return err
-	// 			}
-	// 			return nil
-	// 		},
-	// 		time.Second,
-	// 		30*time.Second,
-	// 		"failed to test resources",
-	// 	)
-	// }()
+	defer func() {
+		require.NoError(t, commander.Mayday(ctx, "modes-airway", ""))
+
+		airwayIntf := client.Dynamic.Resource(schema.GroupVersionResource{
+			Group:    "yoke.cd",
+			Version:  "v1alpha1",
+			Resource: "airways",
+		})
+
+		testutils.EventuallyNoErrorf(
+			t,
+			func() error {
+				_, err := airwayIntf.Get(ctx, "backends.examples.com", metav1.GetOptions{})
+				if err == nil {
+					return fmt.Errorf("backends.examples.com has not been removed")
+				}
+				if !kerrors.IsNotFound(err) {
+					return err
+				}
+				return nil
+			},
+			time.Second,
+			30*time.Second,
+			"failed to test resources",
+		)
+	}()
 
 	require.NoError(t, commander.Takeoff(ctx, yoke.TakeoffParams{
 		Release: "test",
@@ -1217,6 +1220,9 @@ func TestAirwayModes(t *testing.T) {
 		Wait: 30 * time.Second,
 		Poll: time.Second,
 	}))
+	defer func() {
+		require.NoError(t, commander.Mayday(ctx, "test", "default"))
+	}()
 
 	deploymentIntf := client.Clientset.AppsV1().Deployments("default")
 

--- a/cmd/yoke/cmd_turbulence.go
+++ b/cmd/yoke/cmd_turbulence.go
@@ -37,6 +37,7 @@ func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulencePar
 	params := TurbulenceParams{GlobalSettings: settings}
 
 	RegisterGlobalFlags(flagset, &params.GlobalSettings)
+
 	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff")
 	flagset.BoolVar(
 		&params.ConflictsOnly,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yokecd/yoke
 
-go 1.24.0
+go 1.24.2
 
 require (
 	github.com/alecthomas/chroma/v2 v2.15.0
@@ -43,7 +43,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
+	github.com/charmbracelet/colorprofile v0.3.0 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
@@ -58,7 +58,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
@@ -123,7 +123,7 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yokecd/yoke
 
-go 1.24.2
+go 1.24.0
 
 require (
 	github.com/alecthomas/chroma/v2 v2.15.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQW
 github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
 github.com/charmbracelet/bubbletea v1.3.4 h1:kCg7B+jSCFPLYRA52SDZjr51kG/fMUEoPoZrkaDHyoI=
 github.com/charmbracelet/bubbletea v1.3.4/go.mod h1:dtcUCyCGEX3g9tosuYiut3MXgY/Jsv9nKVdibKKRRXo=
-github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
-github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc/go.mod h1:X4/0JoqgTIPSFcRA/P6INZzIuyqdFY5rm8tb41s9okk=
+github.com/charmbracelet/colorprofile v0.3.0 h1:KtLh9uuu1RCt+Hml4s6Hz+kB1PfV3wi++1h5ia65yKQ=
+github.com/charmbracelet/colorprofile v0.3.0/go.mod h1:oHJ340RS2nmG1zRGPmhJKJ/jf4FPNNk0P39/wBPA1G0=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
 github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2llXn7xE=
@@ -92,8 +92,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
-github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
+github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
@@ -295,8 +295,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
 golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -107,7 +107,7 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 
 	airwayStatus := func(status string, msg any) {
 		var err error
-		airway, err = airwayIntf.Get(ctx, airway.GetName(), metav1.GetOptions{})
+		airway, err = airwayIntf.Get(ctx, event.Name, metav1.GetOptions{})
 		if err != nil {
 			ctrl.Logger(ctx).Error("failed to update airway status", "error", fmt.Errorf("failed to get airway: %v", err))
 			return
@@ -512,7 +512,7 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 
 		flightStatus := func(status string, msg any) {
 			var err error
-			resource, err = resourceIntf.Get(ctx, resource.GetName(), metav1.GetOptions{})
+			resource, err = resourceIntf.Get(ctx, event.Name, metav1.GetOptions{})
 			if err != nil {
 				ctrl.Logger(ctx).Error("failed to update flight status", "error", fmt.Errorf("failed to get flight: %v", err))
 				return
@@ -524,7 +524,7 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 				"status",
 			)
 
-			updated, err := resourceIntf.UpdateStatus(ctx, resource.DeepCopy(), metav1.UpdateOptions{FieldManager: fieldManager})
+			updated, err := resourceIntf.UpdateStatus(ctx, resource, metav1.UpdateOptions{FieldManager: fieldManager})
 			if err != nil {
 				ctrl.Logger(ctx).Error("failed to update flight status", "error", err)
 				return

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -109,6 +109,9 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 		var err error
 		airway, err = airwayIntf.Get(ctx, event.Name, metav1.GetOptions{})
 		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return
+			}
 			ctrl.Logger(ctx).Error("failed to update airway status", "error", fmt.Errorf("failed to get airway: %v", err))
 			return
 		}
@@ -121,6 +124,9 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 
 		updated, err := airwayIntf.UpdateStatus(ctx, airway, metav1.UpdateOptions{FieldManager: fieldManager})
 		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return
+			}
 			ctrl.Logger(ctx).Error("failed to update airway status", "error", err)
 			return
 		}
@@ -514,6 +520,9 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 			var err error
 			resource, err = resourceIntf.Get(ctx, event.Name, metav1.GetOptions{})
 			if err != nil {
+				if kerrors.IsNotFound(err) {
+					return
+				}
 				ctrl.Logger(ctx).Error("failed to update flight status", "error", fmt.Errorf("failed to get flight: %v", err))
 				return
 			}
@@ -526,6 +535,9 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 
 			updated, err := resourceIntf.UpdateStatus(ctx, resource, metav1.UpdateOptions{FieldManager: fieldManager})
 			if err != nil {
+				if kerrors.IsNotFound(err) {
+					return
+				}
 				ctrl.Logger(ctx).Error("failed to update flight status", "error", err)
 				return
 			}

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -503,11 +503,11 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 		}
 
 		overrideMode := func() v1alpha1.AirwayMode {
-			labels := resource.GetLabels()
-			if labels == nil {
+			annotations := resource.GetAnnotations()
+			if annotations == nil {
 				return ""
 			}
-			override := v1alpha1.AirwayMode(labels[flight.AnnotationOverrideMode])
+			override := v1alpha1.AirwayMode(annotations[flight.AnnotationOverrideMode])
 			if !slices.Contains(v1alpha1.Modes(), override) {
 				return ""
 			}

--- a/internal/atc/wasm/cache.go
+++ b/internal/atc/wasm/cache.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/yokecd/yoke/internal/wasi"
+	"github.com/yokecd/yoke/internal/xsync"
 )
 
 type Type interface {
@@ -28,11 +29,11 @@ func AirwayModuleDir(airwayName string) string {
 }
 
 type ModuleCache struct {
-	modules sync.Map
+	modules xsync.Map[string, *Modules]
 }
 
 func (cache *ModuleCache) Get(name string) *Modules {
-	lock, _ := cache.modules.LoadOrStore(name, &Modules{
+	modules, _ := cache.modules.LoadOrStore(name, &Modules{
 		Flight: &Module{
 			Module: new(wasi.Module),
 		},
@@ -40,7 +41,7 @@ func (cache *ModuleCache) Get(name string) *Modules {
 			Module: new(wasi.Module),
 		},
 	})
-	return lock.(*Modules)
+	return modules
 }
 
 func (cache *ModuleCache) Delete(name string) {

--- a/internal/k8s/ctrl/queue.go
+++ b/internal/k8s/ctrl/queue.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"sync"
+
+	"github.com/yokecd/yoke/internal/xsync"
 )
 
 type Queue[T fmt.Stringer] struct {
-	barrier *sync.Map
+	barrier *xsync.Map[string, struct{}]
 	buffer  []T
 	lock    *sync.Mutex
 	pipe    chan T
@@ -52,7 +54,7 @@ func (queue *Queue[t]) tryUnshift() {
 // determined by fmt.Stringer.
 func QueueFromChannel[T fmt.Stringer](c chan T) (*Queue[T], func()) {
 	queue := Queue[T]{
-		barrier: &sync.Map{},
+		barrier: &xsync.Map[string, struct{}]{},
 		buffer:  []T{},
 		lock:    &sync.Mutex{},
 		pipe:    make(chan T, 1),

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path"
 	"runtime"
 	"slices"
 	"strconv"
@@ -216,8 +215,8 @@ func (client Client) checkOwnership(ctx context.Context, resource *unstructured.
 		return fmt.Errorf("failed to get resource: %w", err)
 	}
 
-	localOwner := path.Join(resource.GetLabels()[internal.LabelYokeReleaseNS], resource.GetLabels()[internal.LabelYokeRelease])
-	svrOwner := path.Join(svrResource.GetLabels()[internal.LabelYokeReleaseNS], svrResource.GetLabels()[internal.LabelYokeRelease])
+	localOwner := internal.GetOwner(resource)
+	svrOwner := internal.GetOwner(svrResource)
 
 	if localOwner != svrOwner {
 		return fmt.Errorf("expected release %q but resource is already owned by %q", localOwner, svrOwner)

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -248,13 +248,13 @@ func (client Client) RemoveOrphans(ctx context.Context, previous, current intern
 
 				defer internal.DebugTimer(ctx, "delete resource "+name)()
 
-				resourceInterface, err := client.GetDynamicResourceInterface(resource)
+				intf, err := client.GetDynamicResourceInterface(resource)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to resolve resource %s: %w", name, err))
 					return
 				}
 
-				if err := resourceInterface.Delete(ctx, resource.GetName(), metav1.DeleteOptions{}); err != nil {
+				if err := intf.Delete(ctx, resource.GetName(), metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 					errs = append(errs, fmt.Errorf("failed to delete %s: %w", name, err))
 					return
 				}

--- a/internal/revision.go
+++ b/internal/revision.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -122,6 +123,36 @@ func GetOwner(resource *unstructured.Unstructured) string {
 	}
 
 	return namespace + "/" + release
+}
+
+// RemoveAdditions removes fields from actual that are not in expected.
+// it removes the additional properties in place and returns "actual" back.
+// Values passed to removeAdditions are expected to be generic json compliant structures:
+// map[string]any, []any, or scalars.
+func RemoveAdditions[T any](expected, actual T) T {
+	// Check if we can access the types safely
+	if !reflect.ValueOf(expected).IsValid() || !reflect.ValueOf(actual).IsValid() || reflect.ValueOf(actual).Type() != reflect.ValueOf(expected).Type() {
+		return actual
+	}
+
+	switch a := any(actual).(type) {
+	case map[string]any:
+		e := any(expected).(map[string]any)
+		for key := range a {
+			if _, ok := e[key]; !ok {
+				delete(a, key)
+				continue
+			}
+			a[key] = RemoveAdditions(e[key], a[key])
+		}
+	case []any:
+		e := any(expected).([]any)
+		for i := range min(len(a), len(e)) {
+			a[i] = RemoveAdditions(e[i], a[i])
+		}
+	}
+
+	return actual
 }
 
 func Canonical(resource *unstructured.Unstructured) string {

--- a/internal/revision.go
+++ b/internal/revision.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -123,36 +122,6 @@ func GetOwner(resource *unstructured.Unstructured) string {
 	}
 
 	return namespace + "/" + release
-}
-
-// RemoveAdditions removes fields from actual that are not in expected.
-// it removes the additional properties in place and returns "actual" back.
-// Values passed to removeAdditions are expected to be generic json compliant structures:
-// map[string]any, []any, or scalars.
-func RemoveAdditions[T any](expected, actual T) T {
-	// Check if we can access the types safely
-	if !reflect.ValueOf(expected).IsValid() || !reflect.ValueOf(actual).IsValid() || reflect.ValueOf(actual).Type() != reflect.ValueOf(expected).Type() {
-		return actual
-	}
-
-	switch a := any(actual).(type) {
-	case map[string]any:
-		e := any(expected).(map[string]any)
-		for key := range a {
-			if _, ok := e[key]; !ok {
-				delete(a, key)
-				continue
-			}
-			a[key] = RemoveAdditions(e[key], a[key])
-		}
-	case []any:
-		e := any(expected).([]any)
-		for i := range min(len(a), len(e)) {
-			a[i] = RemoveAdditions(e[i], a[i])
-		}
-	}
-
-	return actual
 }
 
 func Canonical(resource *unstructured.Unstructured) string {

--- a/internal/revision.go
+++ b/internal/revision.go
@@ -105,18 +105,23 @@ func AddYokeMetadata(resources []*unstructured.Unstructured, release, ns string)
 	}
 }
 
-func GetOwner(resource unstructured.Unstructured) string {
+func GetOwner(resource *unstructured.Unstructured) string {
+	if resource == nil {
+		return ""
+	}
+
 	labels := resource.GetLabels()
 	if labels == nil {
 		return ""
 	}
 
 	release := labels[LabelYokeRelease]
-	if release == "" {
+	namespace := labels[LabelYokeReleaseNS]
+	if release == "" || namespace == "" {
 		return ""
 	}
 
-	return labels[LabelYokeReleaseNS] + "/" + release
+	return namespace + "/" + release
 }
 
 func Canonical(resource *unstructured.Unstructured) string {

--- a/internal/revision.go
+++ b/internal/revision.go
@@ -105,6 +105,20 @@ func AddYokeMetadata(resources []*unstructured.Unstructured, release, ns string)
 	}
 }
 
+func GetOwner(resource unstructured.Unstructured) string {
+	labels := resource.GetLabels()
+	if labels == nil {
+		return ""
+	}
+
+	release := labels[LabelYokeRelease]
+	if release == "" {
+		return ""
+	}
+
+	return labels[LabelYokeReleaseNS] + "/" + release
+}
+
 func Canonical(resource *unstructured.Unstructured) string {
 	gvk := resource.GetObjectKind().GroupVersionKind()
 

--- a/internal/unstructured.go
+++ b/internal/unstructured.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -24,4 +25,66 @@ func ToUnstructured(value any) (*unstructured.Unstructured, error) {
 func MustUnstructuredObject(value any) map[string]any {
 	result, _ := UnstructuredObject(value)
 	return result
+}
+
+func ResourcesAreEqual(a, b *unstructured.Unstructured) bool {
+	if (a == nil) || (b == nil) {
+		return false
+	}
+
+	dropKeys := [][]string{
+		{"metadata", "generation"},
+		{"metadata", "resourceVersion"},
+		{"metadata", "managedFields"},
+		{"status"},
+	}
+
+	return reflect.DeepEqual(
+		DropProperties(a, dropKeys).Object,
+		DropProperties(b, dropKeys).Object,
+	)
+}
+
+func DropProperties(resource *unstructured.Unstructured, props [][]string) *unstructured.Unstructured {
+	if resource == nil {
+		return nil
+	}
+
+	resource = resource.DeepCopy()
+
+	for _, keys := range props {
+		unstructured.RemoveNestedField(resource.Object, keys...)
+	}
+
+	return resource
+}
+
+// RemoveAdditions removes fields from actual that are not in expected.
+// it removes the additional properties in place and returns "actual" back.
+// Values passed to removeAdditions are expected to be generic json compliant structures:
+// map[string]any, []any, or scalars.
+func RemoveAdditions[T any](expected, actual T) T {
+	// Check if we can access the types safely
+	if !reflect.ValueOf(expected).IsValid() || !reflect.ValueOf(actual).IsValid() || reflect.ValueOf(actual).Type() != reflect.ValueOf(expected).Type() {
+		return actual
+	}
+
+	switch a := any(actual).(type) {
+	case map[string]any:
+		e := any(expected).(map[string]any)
+		for key := range a {
+			if _, ok := e[key]; !ok {
+				delete(a, key)
+				continue
+			}
+			a[key] = RemoveAdditions(e[key], a[key])
+		}
+	case []any:
+		e := any(expected).([]any)
+		for i := range min(len(a), len(e)) {
+			a[i] = RemoveAdditions(e[i], a[i])
+		}
+	}
+
+	return actual
 }

--- a/internal/xsync/map.go
+++ b/internal/xsync/map.go
@@ -1,0 +1,14 @@
+package xsync
+
+import "sync"
+
+type Map[K comparable, V any] sync.Map
+
+func (m *Map[K, V]) LoadOrStore(key K, value V) (V, bool) {
+	result, ok := (*sync.Map)(m).LoadOrStore(key, value)
+	return result.(V), ok
+}
+
+func (m *Map[K, V]) Delete(key K) {
+	(*sync.Map)(m).Delete(key)
+}

--- a/internal/xsync/map.go
+++ b/internal/xsync/map.go
@@ -4,6 +4,19 @@ import "sync"
 
 type Map[K comparable, V any] sync.Map
 
+func (m *Map[K, V]) Load(key K) (V, bool) {
+	result, ok := (*sync.Map)(m).Load(key)
+	if !ok {
+		var zero V
+		return zero, ok
+	}
+	return result.(V), ok
+}
+
+func (m *Map[K, V]) Store(key K, value V) {
+	(*sync.Map)(m).Store(key, value)
+}
+
 func (m *Map[K, V]) LoadOrStore(key K, value V) (V, bool) {
 	result, ok := (*sync.Map)(m).LoadOrStore(key, value)
 	return result.(V), ok

--- a/pkg/apis/airway/v1alpha1/airway.go
+++ b/pkg/apis/airway/v1alpha1/airway.go
@@ -31,7 +31,7 @@ func (AirwayMode) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
 		Type: "string",
 		Enum: func() []apiextensionsv1.JSON {
 			var result []apiextensionsv1.JSON
-			for _, value := range []AirwayMode{AirwayModeNormal, AirwayModeStatic, AirwayModeDynamic} {
+			for _, value := range []AirwayMode{AirwayModeStandard, AirwayModeStatic, AirwayModeDynamic} {
 				data, _ := json.Marshal(value)
 				result = append(result, apiextensionsv1.JSON{Raw: data})
 			}
@@ -41,9 +41,9 @@ func (AirwayMode) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
 }
 
 const (
-	AirwayModeNormal  AirwayMode = "normal"
-	AirwayModeStatic  AirwayMode = "static"
-	AirwayModeDynamic AirwayMode = "dynamic"
+	AirwayModeStandard AirwayMode = "standard"
+	AirwayModeStatic   AirwayMode = "static"
+	AirwayModeDynamic  AirwayMode = "dynamic"
 )
 
 type AirwaySpec struct {
@@ -80,7 +80,7 @@ type AirwaySpec struct {
 
 	// Mode sets different behaviors for how the child resources of flights are managed by the ATC.
 	//
-	// - "normal" is the same not specifying any mode. In "normal" mode, flights are evaluated once
+	// - "standard" is the same not specifying any mode. In "standard" mode, flights are evaluated once
 	// and child resources are applied, and no further evaluation is made should child resources be modified.
 	//
 	// - "static" mode checks any change to a child resource against desired state at admission time.

--- a/pkg/apis/airway/v1alpha1/airway.go
+++ b/pkg/apis/airway/v1alpha1/airway.go
@@ -31,7 +31,7 @@ func (AirwayMode) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
 		Type: "string",
 		Enum: func() []apiextensionsv1.JSON {
 			var result []apiextensionsv1.JSON
-			for _, value := range []AirwayMode{AirwayModeStandard, AirwayModeStatic, AirwayModeDynamic} {
+			for _, value := range Modes() {
 				data, _ := json.Marshal(value)
 				result = append(result, apiextensionsv1.JSON{Raw: data})
 			}
@@ -45,6 +45,11 @@ const (
 	AirwayModeStatic   AirwayMode = "static"
 	AirwayModeDynamic  AirwayMode = "dynamic"
 )
+
+// Modes returns the list of known Airway modes.
+func Modes() []AirwayMode {
+	return []AirwayMode{AirwayModeStandard, AirwayModeStatic, AirwayModeDynamic}
+}
 
 type AirwaySpec struct {
 	// WasmURLs defines the locations for the various implementations the AirTrafficController will invoke.

--- a/pkg/flight/flight.go
+++ b/pkg/flight/flight.go
@@ -34,7 +34,10 @@ type Status struct {
 	Msg string `json:"msg,omitempty"`
 }
 
-const AnnotationOverrideFlight = "overrides.yoke.cd/flight"
+const (
+	AnnotationOverrideFlight = "overrides.yoke.cd/flight"
+	AnnotationOverrideMode   = "overrides.yoke.cd/mode"
+)
 
 // Resource is a best effort attempt at capturing the set of types that are kubernetes resources.
 // K8s resource embed the metav1.TypeMeta struct and thus expose this method; unstructured.Unstructured objects also expose it.

--- a/pkg/openapi/flight.golden.json
+++ b/pkg/openapi/flight.golden.json
@@ -26,7 +26,7 @@
         "mode": {
           "type": "string",
           "enum": [
-            "normal",
+            "standard",
             "static",
             "dynamic"
           ]

--- a/pkg/openapi/flight.golden.json
+++ b/pkg/openapi/flight.golden.json
@@ -23,6 +23,14 @@
         "insecure": {
           "type": "boolean"
         },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "static",
+            "dynamic"
+          ]
+        },
         "objectPath": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Related to #106 

Experimental resource watcher that allows us to validate against yoke label changes,
and possibly trigger events when external actors modify flight sub-resources.

