### PR TITLE
develop

### DIFF
--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -53,7 +53,7 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 		converter.RLock()
 		defer converter.RUnlock()
 
-		if converter.CompiledModule == nil {
+		if converter.Instance.CompiledModule == nil {
 			http.Error(w, "converter module not ready or validations not managed by this server", http.StatusNotFound)
 			return
 		}
@@ -80,7 +80,7 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 		}
 
 		resp, err := wasi.Execute(ctx, wasi.ExecParams{
-			Module:  converter.Module,
+			Module:  converter.Instance,
 			Stdin:   bytes.NewReader(data),
 			Release: "converter",
 		})
@@ -215,7 +215,7 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 			flightMod.RLock()
 			defer flightMod.RUnlock()
 
-			if flightMod.CompiledModule == nil {
+			if flightMod.Instance.CompiledModule == nil {
 				http.Error(w, "flight not ready or not registered for custom resource", http.StatusNotFound)
 				return
 			}

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -1029,6 +1029,11 @@ func TestHistoryCap(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, release.History, 2)
 
+	for _, revision := range release.History {
+		require.Equal(t, "http://wasmcache/flight.v1.wasm", revision.Source.Ref)
+		require.NotEmpty(t, revision.Source.Checksum)
+	}
+
 	slices.SortStableFunc(release.History, func(a, b internal.Revision) int {
 		return b.ActiveAt.Compare(a.ActiveAt)
 	})

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -71,6 +71,8 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 	flagset.DurationVar(&params.Wait, "wait", 0, "time to wait for release to be ready")
 	flagset.DurationVar(&params.Poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
 
+	flagset.IntVar(&params.HistoryCapSize, "history-cap", 10, "max number of revisions to keep in release history. 0 or less is unbounded.")
+
 	flagset.StringVar(&params.Flight.CompilationCacheDir, "compilation-cache", "", "location to cache wasm compilations")
 
 	args, params.Flight.Args = internal.CutArgs(args)

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -640,6 +640,7 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 				Input:     bytes.NewReader(data),
 				Namespace: event.Namespace,
 			},
+			HistoryCapSize: cmp.Or(params.Airway.Spec.HistoryCapSize, 2),
 			ClusterAccess:  params.Airway.Spec.ClusterAccess,
 			CrossNamespace: params.Airway.Spec.CrossNamespace,
 			OwnerReferences: []metav1.OwnerReference{

--- a/pkg/apis/airway/v1alpha1/airway.go
+++ b/pkg/apis/airway/v1alpha1/airway.go
@@ -96,6 +96,11 @@ type AirwaySpec struct {
 	// build new desired state based on external changes to child resources.
 	Mode AirwayMode `json:"mode,omitempty"`
 
+	// HistoryCapSize controls how many revisions of an instance (custom resource) of this airway is kept in history.
+	// To make it uncapped set this value to any negative integer.
+	// By default 2.
+	HistoryCapSize int `json:"historyCapSize,omitempty"`
+
 	// Template is the CustomResourceDefinition Specification to create. A CRD will be created using this specification
 	// and bound to the implementation defined by the WasmURLs.Flight property.
 	Template apiextensionsv1.CustomResourceDefinitionSpec `json:"template"`

--- a/pkg/openapi/flight.golden.json
+++ b/pkg/openapi/flight.golden.json
@@ -20,6 +20,9 @@
         "fixDriftInterval": {
           "type": "string"
         },
+        "historyCapSize": {
+          "type": "integer"
+        },
         "insecure": {
           "type": "boolean"
         },

--- a/pkg/yoke/wasm.go
+++ b/pkg/yoke/wasm.go
@@ -102,13 +102,13 @@ func gzipReader(r io.Reader) io.Reader {
 }
 
 func EvalFlight(ctx context.Context, client *k8s.Client, release string, flight FlightParams) ([]byte, []byte, error) {
-	if flight.Input != nil && flight.Path == "" && flight.Module == nil {
+	if flight.Input != nil && flight.Path == "" && flight.Module.Instance == nil {
 		output, err := io.ReadAll(flight.Input)
 		return output, nil, err
 	}
 
 	wasm, err := func() ([]byte, error) {
-		if flight.Module != nil {
+		if flight.Module.Instance != nil {
 			return nil, nil
 		}
 		return LoadWasm(ctx, flight.Path, flight.Insecure)
@@ -119,7 +119,7 @@ func EvalFlight(ctx context.Context, client *k8s.Client, release string, flight 
 
 	output, err := wasi.Execute(ctx, wasi.ExecParams{
 		Wasm:    wasm,
-		Module:  flight.Module,
+		Module:  flight.Module.Instance,
 		Release: release,
 		Stdin:   flight.Input,
 		Stderr:  flight.Stderr,

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -150,7 +150,7 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) er
 
 	if len(params.OwnerReferences) > 0 {
 		for _, resource := range stages.Flatten() {
-			resource.SetOwnerReferences(params.OwnerReferences)
+			resource.SetOwnerReferences(append(resource.GetOwnerReferences(), params.OwnerReferences...))
 		}
 	}
 


### PR DESCRIPTION
- **atc: add airway as an owner reference to cr instances**
- **internal/k8s: support airway owned flight resource readiness**
