### PR TITLE
external resource access

### DIFF
--- a/cmd/atc/dockerwatcher.go
+++ b/cmd/atc/dockerwatcher.go
@@ -58,7 +58,7 @@ func WatchDockerConfig(ctx context.Context, params WatchDockerConfigParams) erro
 		params.Logger.Info("init: successfully setup docker credentials from secret", "secretName", params.SecretName)
 	}
 
-	watcher, err := retryWatcher.NewRetryWatcher(cmp.Or(secrets.ResourceVersion, "1"), &kcache.ListWatch{
+	watcher, err := retryWatcher.NewRetryWatcherWithContext(ctx, cmp.Or(secrets.ResourceVersion, "1"), &kcache.ListWatch{
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return secretIntf.Watch(ctx, opts)

--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -188,9 +188,10 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 		}
 
 		params := yoke.TakeoffParams{
-			Release:        atc.ReleaseName(&cr),
-			CrossNamespace: airway.Spec.CrossNamespace,
-			ClusterAccess:  airway.Spec.ClusterAccess,
+			Release:               atc.ReleaseName(&cr),
+			CrossNamespace:        airway.Spec.CrossNamespace,
+			ClusterAccess:         airway.Spec.ClusterAccess,
+			ClusterResourceAccess: airway.Spec.ResourceAccessMatchers,
 			Flight: yoke.FlightParams{
 				Input:     bytes.NewReader(data),
 				Namespace: cr.GetNamespace(),

--- a/cmd/atc/internal/testing/Dockerfile.wasmcache
+++ b/cmd/atc/internal/testing/Dockerfile.wasmcache
@@ -16,6 +16,7 @@ RUN \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/converter.wasm ./cmd/atc/internal/testing/apis/backend/converter && \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/crossnamespace.wasm ./cmd/atc/internal/testing/flights/crossnamespace && \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/longrunning.wasm ./cmd/atc/internal/testing/flights/longrunning && \
+  GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/resourceaccessmatchers.wasm ./cmd/atc/internal/testing/flights/resourceaccessmatchers && \
   go build -o ./bin/server ./cmd/atc/internal/testing/wasmcache
 
 FROM alpine

--- a/cmd/atc/internal/testing/flights/resourceaccessmatchers/main.go
+++ b/cmd/atc/internal/testing/flights/resourceaccessmatchers/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/yokecd/yoke/pkg/flight/wasi/k8s"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// This implementation exists to test accessResourceMatchers.
+// This release owns a single configmap but loads two secrets from different namespaces.
+// The test will need to show that with appropriate matchers this works, and without matcher or with inappropriate matchers
+// we get appropriate errors on admission.
+func run() error {
+	secretOne, err := k8s.Lookup[corev1.Secret](k8s.ResourceIdentifier{
+		Name:       "one",
+		Namespace:  "default",
+		Kind:       "Secret",
+		ApiVersion: "v1",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to lookup secret one: %w", err)
+	}
+
+	secretTwo, err := k8s.Lookup[corev1.Secret](k8s.ResourceIdentifier{
+		Name:       "two",
+		Namespace:  "custom",
+		Kind:       "Secret",
+		ApiVersion: "v1",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to lookup secret two: %w", err)
+	}
+
+	dataOne, err := json.Marshal(secretOne.Data)
+	if err != nil {
+		return err
+	}
+
+	dataTwo, err := json.Marshal(secretTwo.Data)
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(
+		&corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cm",
+			},
+			Data: map[string]string{
+				"one": string(dataOne),
+				"two": string(dataTwo),
+			},
+		},
+	)
+}

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -75,6 +75,15 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 
 	flagset.StringVar(&params.Flight.CompilationCacheDir, "compilation-cache", "", "location to cache wasm compilations")
 
+	flagset.Func(
+		"resource-access",
+		"allows flights with cluster-access to read resources outside of the release that match pattern. This flag can be set many times and matchers can be comma separated.",
+		func(s string) error {
+			params.ClusterResourceAccess = append(params.ClusterResourceAccess, strings.Split(s, ",")...)
+			return nil
+		},
+	)
+
 	args, params.Flight.Args = internal.CutArgs(args)
 
 	flagset.Parse(args)
@@ -99,7 +108,7 @@ func TakeOff(ctx context.Context, params TakeoffParams) error {
 	}
 
 	// We want the CLI to stream stderr back to the user instead of buffering.
-	params.TakeoffParams.Flight.Stderr = internal.Stderr(ctx)
+	params.Flight.Stderr = internal.Stderr(ctx)
 
 	return commander.Takeoff(ctx, params.TakeoffParams)
 }

--- a/cmd/yoke/main_test.go
+++ b/cmd/yoke/main_test.go
@@ -1030,6 +1030,50 @@ func TestLookupResource(t *testing.T) {
 	)
 
 	require.Contains(t, stderr.String(), "cannot access resource outside of target release ownership")
+
+	require.ErrorContains(
+		t,
+		TakeOff(ctx, TakeoffParams{
+			GlobalSettings: settings,
+			TakeoffParams: yoke.TakeoffParams{
+				Release:               "foo",
+				CreateNamespace:       true,
+				ClusterAccess:         true,
+				ClusterResourceAccess: []string{"default/Configmap"},
+				Flight: yoke.FlightParams{
+					Path:      "./test_output/flight.wasm",
+					Namespace: "foo",
+					Input:     strings.NewReader(`{"Namespace": "default"}`),
+				},
+				Wait: 10 * time.Second,
+				Poll: time.Second,
+			},
+		}),
+		"exit_code(1)",
+	)
+
+	require.Contains(t, stderr.String(), "cannot access resource outside of target release ownership")
+
+	require.NoError(
+		t,
+		TakeOff(ctx, TakeoffParams{
+			GlobalSettings: settings,
+			TakeoffParams: yoke.TakeoffParams{
+				Release:               "foo",
+				CreateNamespace:       true,
+				ClusterAccess:         true,
+				ClusterResourceAccess: []string{"default/*", "foo/*"},
+				Flight: yoke.FlightParams{
+					Path:      "./test_output/flight.wasm",
+					Namespace: "foo",
+					Input:     strings.NewReader(`{"Namespace": "default"}`),
+				},
+				Wait: 10 * time.Second,
+				Poll: time.Second,
+			},
+		}),
+		"exit_code(1)",
+	)
 }
 
 func TestOciFlight(t *testing.T) {

--- a/cmd/yokecd/main.go
+++ b/cmd/yokecd/main.go
@@ -99,7 +99,7 @@ func run(ctx context.Context, cfg Config) (err error) {
 			return nil, fmt.Errorf("failed to get wasm path: %w", err)
 		}
 
-		data, _, err := yoke.EvalFlight(ctx, client, cfg.Application.Name, yoke.FlightParams{
+		data, _, err := yoke.EvalFlight(ctx, client, cfg.Application.Name, nil, yoke.FlightParams{
 			Path:      wasmPath,
 			Input:     strings.NewReader(cfg.Flight.Input),
 			Args:      cfg.Flight.Args,

--- a/examples/unsafelookup/main.go
+++ b/examples/unsafelookup/main.go
@@ -1,0 +1,58 @@
+// This lookup is unsafe as the flight can try and read arbitrary secrets and write them to a configmap.
+// This example exists to test resource-access matchers. By default flights with cluster access can only read
+// the resources that are owned by the release. Hence this flight with cluster-access can only read the configmap it outputs.
+// It cannot read any sercrets from the cluster. However we can use the `-resource-access` flag to allow it access to sensitive data.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/yokecd/yoke/pkg/flight"
+	"github.com/yokecd/yoke/pkg/flight/wasi/k8s"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	identifier := k8s.ResourceIdentifier{
+		Kind:       "Secret",
+		ApiVersion: "v1",
+	}
+	if err := yaml.NewYAMLToJSONDecoder(os.Stdin).Decode(&identifier); err != nil {
+		return fmt.Errorf("failed to decode input: %w", err)
+	}
+
+	secret, err := k8s.Lookup[corev1.Secret](identifier)
+	if err != nil && !k8s.IsErrNotFound(err) {
+		return err
+	}
+
+	data, err := json.Marshal(secret)
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: flight.Release(),
+		},
+		Data: map[string]string{
+			"data": string(data),
+		},
+	})
+}

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -262,7 +262,7 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 			}
 			mod, err := wasi.Compile(ctx, wasi.CompileParams{
 				Wasm:           data,
-				LookupResource: wasi.HostLookupResource(ctrl.Client(ctx), nil),
+				LookupResource: wasi.HostLookupResource(ctrl.Client(ctx), typedAirway.Spec.ResourceAccessMatchers),
 			})
 			if err != nil {
 				return fmt.Errorf("failed to compile wasm: %w", err)
@@ -651,9 +651,10 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 				Input:     bytes.NewReader(data),
 				Namespace: event.Namespace,
 			},
-			HistoryCapSize: cmp.Or(params.Airway.Spec.HistoryCapSize, 2),
-			ClusterAccess:  params.Airway.Spec.ClusterAccess,
-			CrossNamespace: params.Airway.Spec.CrossNamespace,
+			HistoryCapSize:        cmp.Or(params.Airway.Spec.HistoryCapSize, 2),
+			ClusterAccess:         params.Airway.Spec.ClusterAccess,
+			ClusterResourceAccess: params.Airway.Spec.ResourceAccessMatchers,
+			CrossNamespace:        params.Airway.Spec.CrossNamespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: resource.GetAPIVersion(),

--- a/internal/matcher.go
+++ b/internal/matcher.go
@@ -18,22 +18,25 @@ func MatchResource(resource *unstructured.Unstructured, matcher string) bool {
 		ns, gkn, ok := strings.Cut(matcher, "/")
 		if !ok {
 			gkn = ns
-			ns = ""
+			ns = "*"
 		}
-		gk, name, _ := strings.Cut(gkn, ":")
+		gk, name, ok := strings.Cut(gkn, ":")
+		if !ok {
+			name = "*"
+		}
 
 		return ns, gk, name
 	}()
 
-	if namespace != "" && resource.GetNamespace() != namespace {
+	if namespace != "*" && resource.GetNamespace() != namespace {
 		return false
 	}
 
-	if resource.GroupVersionKind().GroupKind().String() != gk {
+	if gk != "*" && resource.GroupVersionKind().GroupKind().String() != gk {
 		return false
 	}
 
-	if name != "" && resource.GetName() != name {
+	if name != "*" && resource.GetName() != name {
 		return false
 	}
 

--- a/internal/matcher_test.go
+++ b/internal/matcher_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,51 +21,35 @@ func TestMatchResource(t *testing.T) {
 		},
 	}
 
-	cases := []struct {
-		Matcher  string
-		Expected bool
-	}{
-		{
-			Matcher:  "*",
-			Expected: true,
+	cases := map[bool][]string{
+		true: {
+			"*",
+			"foo/Deployment.apps:test",
+			"Deployment.apps:test",
+			"Deployment.apps",
+			"*/*",
+			"*/Deployment.apps",
+			"foo/Deployment.apps:*",
+			"*/Deployment.apps:*",
 		},
-		{
-			Matcher:  "",
-			Expected: false,
-		},
-		{
-			Matcher:  "foo/Deployment.apps:test",
-			Expected: true,
-		},
-		{
-			Matcher:  "Deployment.apps:test",
-			Expected: true,
-		},
-		{
-			Matcher:  "Deployment.apps",
-			Expected: true,
-		},
-		{
-			Matcher:  "Deployment",
-			Expected: false,
-		},
-		{
-			Matcher:  "bar/Deployment.apps",
-			Expected: false,
-		},
-		{
-			Matcher:  "Deployment.custom:test",
-			Expected: false,
-		},
-		{
-			Matcher:  "Deployment.apps:other",
-			Expected: false,
+		false: {
+			"",
+			"/",
+			"Deployment",
+			"bar/Deployment.apps",
+			"Deployment.custom:test",
+			"Deployment.apps:other",
+			"bar/*",
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.Matcher, func(t *testing.T) {
-			require.Equal(t, tc.Expected, MatchResource(&resource, tc.Matcher))
+	for ok, matchers := range cases {
+		t.Run(strconv.FormatBool(ok), func(t *testing.T) {
+			for _, matcher := range matchers {
+				t.Run(matcher, func(t *testing.T) {
+					require.Equal(t, ok, MatchResource(&resource, matcher))
+				})
+			}
 		})
 	}
 }

--- a/pkg/apis/airway/v1alpha1/airway.go
+++ b/pkg/apis/airway/v1alpha1/airway.go
@@ -68,6 +68,21 @@ type AirwaySpec struct {
 	// ClusterAccess allows the flight to lookup resources in the cluster. Resources are limited to those owned by the calling release.
 	ClusterAccess bool `json:"clusterAccess,omitempty"`
 
+	// ResourceAccessMatchers combined with ClusterAccess allow you to lookup any resource in your cluster. By default without any matchers
+	// the only resources that you can lookup are resources that are directly owned by the release. If you wish to access resources external
+	// to the release you can provide a set of matcher patterns. If any pattern matches, the resource is allowed to by accessed.
+	//
+	// The pattern goes like this: $namespace/$Kind.Group:$name
+	// Where namespace and name are optional. If they are omitted it is the same as setting them to '*'.
+	//
+	// Examples Matchers:
+	// 	- Deployment.apps 							# matches all deployments in your cluster
+	// 	- foo/Deployment.apps 					# matches all deployments in namespace foo
+	// 	- foo/Deployment.apps:example 	# matches a deployment named example in namespace foo.
+	// 	- * 														# matches all resources in the cluster.
+	// 	- foo/* 												# matches all resources in namespace foo.
+	ResourceAccessMatchers []string `json:"resourceAccessMatchers,omitempty"`
+
 	// CrossNamespace allows for resources to be created in other namespaces other than the releases target namespace.
 	CrossNamespace bool `json:"crossNamespace,omitempty"`
 

--- a/pkg/openapi/flight.golden.json
+++ b/pkg/openapi/flight.golden.json
@@ -40,6 +40,12 @@
             "type": "string"
           }
         },
+        "resourceAccessMatchers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "skipAdmissionWebhook": {
           "type": "boolean"
         },

--- a/pkg/yoke/wasm.go
+++ b/pkg/yoke/wasm.go
@@ -101,7 +101,7 @@ func gzipReader(r io.Reader) io.Reader {
 	return pr
 }
 
-func EvalFlight(ctx context.Context, client *k8s.Client, release string, flight FlightParams) ([]byte, []byte, error) {
+func EvalFlight(ctx context.Context, client *k8s.Client, release string, matchers []string, flight FlightParams) ([]byte, []byte, error) {
 	if flight.Input != nil && flight.Path == "" && flight.Module.Instance == nil {
 		output, err := io.ReadAll(flight.Input)
 		return output, nil, err
@@ -130,7 +130,7 @@ func EvalFlight(ctx context.Context, client *k8s.Client, release string, flight 
 			"NAMESPACE":      flight.Namespace,
 		},
 		CacheDir:       flight.CompilationCacheDir,
-		LookupResource: wasi.HostLookupResource(client, nil),
+		LookupResource: wasi.HostLookupResource(client, matchers),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to execute wasm: %w", err)

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -106,6 +106,9 @@ type TakeoffParams struct {
 	// ClusterAccess grants the flight access to the kubernetes cluster. Users will be able to use the host k8s_lookup function.
 	ClusterAccess bool
 
+	// ClusterResourceAccess
+	ClusterResourceAccess []string
+
 	// HistoryCapSize limits the number of revisions kept in the release's history by the size. If Cap is less than 1 history is uncapped.
 	HistoryCapSize int
 }
@@ -122,6 +125,7 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) er
 			return commander.k8s
 		}(),
 		params.Release,
+		params.ClusterResourceAccess,
 		params.Flight,
 	)
 	if err != nil {


### PR DESCRIPTION
Closes #141 

This PR allows flights to access resources outside of the target release by opting in via resource access matchers.

These matchers are defined as strings: `namespace/kind.group:name` where namespace and name are optional and default to `*` which matches anything. `kind.group` can also be set to `*`.

This allows user to control which resources flight are allowed to lookup, allowing flight to depend on shared cluster state in an opt-in fashion.