### PR TITLE
atc/installer: log useful TLS cert generation messages

### DIFF
--- a/cmd/atc-installer/installer/run.go
+++ b/cmd/atc-installer/installer/run.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"reflect"
 	"slices"
 	"strconv"
@@ -164,8 +165,14 @@ func Run(cfg Config) (flight.Stages, error) {
 			Kind:       "Secret",
 			ApiVersion: "v1",
 		})
-		if err != nil && !k8s.IsErrNotFound(err) && !errors.Is(err, k8s.ErrorClusterAccessNotGranted) {
-			return nil, fmt.Errorf("failed to lookup tls secret: %T: %v", err, err)
+		if err != nil {
+			if !k8s.IsErrNotFound(err) && !errors.Is(err, k8s.ErrorClusterAccessNotGranted) {
+				return nil, fmt.Errorf("failed to lookup tls secret: %T: %v", err, err)
+			}
+
+			if errors.Is(err, k8s.ErrorClusterAccessNotGranted) {
+				fmt.Fprintln(os.Stderr, "Cluster-access not granted: enable cluster-access to reuse existing TLS certificates.")
+			}
 		}
 		if secret != nil {
 			return &TLS{

--- a/cmd/atc-installer/installer/tls.go
+++ b/cmd/atc-installer/installer/tls.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +25,8 @@ type TLS struct {
 const org = "yoke.cd"
 
 func NewTLS(svc *corev1.Service) (*TLS, error) {
+	fmt.Fprintln(os.Stderr, "Generating TLS certificates, this may take a second...")
+
 	rootTemplate := x509.Certificate{
 		SerialNumber: big.NewInt(1991),
 		Subject: pkix.Name{
@@ -94,6 +97,8 @@ func NewTLS(svc *corev1.Service) (*TLS, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode server key to PEM: %w", err)
 	}
+
+	fmt.Fprintln(os.Stderr, "Finished generating TLS certificates.")
 
 	return &TLS{
 		RootCA:     rootCa,


### PR DESCRIPTION
Log that TLS installing may take a while
Log that cluster-access allows flights to reuse existing TLS certs