### PR TITLE
yoke apply should reassert cluster state

### DIFF
--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -1706,7 +1706,7 @@ func TestAirwayModes(t *testing.T) {
 			}
 			deployment.Spec.Replicas = ptr.To[int32](5)
 			expectedErr := `admission webhook "resources.yoke.cd" denied the request: cannot modify flight sub-resources`
-			deployment, err = deploymentIntf.Update(ctx, deployment, metav1.UpdateOptions{FieldManager: "test"})
+			deployment, err = deploymentIntf.Update(ctx, deployment, metav1.UpdateOptions{FieldManager: "yoke"})
 			if err == nil {
 				return fmt.Errorf("expected error but got none")
 			}
@@ -1745,7 +1745,7 @@ func TestAirwayModes(t *testing.T) {
 
 	testBE.SetAnnotations(annotations)
 
-	_, err = backendIntf.Update(ctx, testBE, metav1.UpdateOptions{FieldManager: "test"})
+	_, err = backendIntf.Update(ctx, testBE, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	testutils.EventuallyNoErrorf(
@@ -1774,7 +1774,7 @@ func TestAirwayModes(t *testing.T) {
 
 	deployment.Spec.Replicas = ptr.To[int32](8)
 
-	deployment, err = deploymentIntf.Update(ctx, deployment, metav1.UpdateOptions{FieldManager: "test"})
+	deployment, err = deploymentIntf.Update(ctx, deployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
 	require.EqualValues(t, 8, *deployment.Spec.Replicas)
 
@@ -1823,7 +1823,7 @@ func TestAirwayModes(t *testing.T) {
 	// The flight.v1.modes flight lets us set the replicas via the intermediary of our configmap.
 	configmap.Data = map[string]string{"replicas": "7"}
 
-	_, err = configmapIntf.Update(ctx, configmap, metav1.UpdateOptions{FieldManager: "test"})
+	_, err = configmapIntf.Update(ctx, configmap, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	testutils.EventuallyNoErrorf(

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -738,6 +738,7 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 				Input:     bytes.NewReader(data),
 				Namespace: event.Namespace,
 			},
+			ForceConflicts:        true,
 			HistoryCapSize:        cmp.Or(params.Airway.Spec.HistoryCapSize, 2),
 			ClusterAccess:         params.Airway.Spec.ClusterAccess,
 			ClusterResourceAccess: params.Airway.Spec.ResourceAccessMatchers,

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -246,10 +246,6 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) er
 		return fmt.Errorf("failed to get previous resources for revision: %w", err)
 	}
 
-	if reflect.DeepEqual(previous, stages) {
-		return internal.Warning("resources are the same as previous revision: skipping takeoff")
-	}
-
 	if params.CreateNamespace {
 		if err := commander.k8s.EnsureNamespace(ctx, targetNS); err != nil {
 			return fmt.Errorf("failed to ensure namespace: %w", err)
@@ -301,6 +297,10 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) er
 	if params.DryRun {
 		fmt.Fprintf(internal.Stderr(ctx), "successful dry-run takeoff of %s\n", params.Release)
 		return nil
+	}
+
+	if reflect.DeepEqual(previous, stages) {
+		return internal.Warning("resources are the same as previous revision: skipping creation of new revision")
 	}
 
 	now := time.Now()


### PR DESCRIPTION
- **k8s/ctrl: refactor function signature that had unused params**
- **yoke/takeoff: reapply desired state on takeoff even if identical to previous revision**
