### PR TITLE
atc: manage crds and validation webhook resource on startup instead of installer

### DIFF
--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -71,6 +71,10 @@ func run() (err error) {
 		return fmt.Errorf("failed to instantiate kubernetes client: %w", err)
 	}
 
+	if err := ApplyResources(ctx, client, cfg); err != nil {
+		return fmt.Errorf("failed to apply dependent resources: %w", err)
+	}
+
 	moduleCache := new(wasm.ModuleCache)
 	controllers := new(atc.ControllerCache)
 

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -108,6 +108,7 @@ func TestMain(m *testing.M) {
         "image": "yokecd/atc",
         "version": "test"
       }`),
+			Args:      []string{"--skip-version-check"},
 			Namespace: "atc",
 		},
 		CreateNamespace: true,

--- a/cmd/atc/resources.go
+++ b/cmd/atc/resources.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+
+	"github.com/yokecd/yoke/internal"
+	"github.com/yokecd/yoke/internal/k8s"
+	"github.com/yokecd/yoke/pkg/apis/airway/v1alpha1"
+	"github.com/yokecd/yoke/pkg/openapi"
+)
+
+func ApplyResources(ctx context.Context, client *k8s.Client, cfg *Config) error {
+	var (
+		group = "yoke.cd"
+		names = apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "airways",
+			Singular: "airway",
+			Kind:     "Airway",
+		}
+	)
+
+	airwayDef := &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: apiextensionsv1.SchemeGroupVersion.Identifier(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: names.Plural + "." + group,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: names,
+			Scope: apiextensionsv1.ClusterScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[v1alpha1.Airway]()),
+					},
+				},
+			},
+		},
+	}
+
+	airwayResource, err := internal.ToUnstructured(airwayDef)
+	if err != nil {
+		return fmt.Errorf("failed to convert airway crd to its unstructured representation: %w", err)
+	}
+
+	if err := client.ApplyResource(ctx, airwayResource, k8s.ApplyOpts{}); err != nil {
+		return fmt.Errorf("failed to apply airway crd: %w", err)
+	}
+
+	airwayValidation := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: admissionregistrationv1.SchemeGroupVersion.Identifier(),
+			Kind:       "ValidatingWebhookConfiguration",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "atc-airway",
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name: "airways.yoke.cd",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: cfg.Service.Namespace,
+						Name:      cfg.Service.Name,
+						Path:      ptr.To("/validations/airways.yoke.cd"),
+						Port:      &cfg.Service.Port,
+					},
+					CABundle: cfg.Service.CABundle,
+				},
+				SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+				AdmissionReviewVersions: []string{"v1"},
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Create,
+							admissionregistrationv1.Update,
+						},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{"yoke.cd"},
+							APIVersions: []string{"v1alpha1"},
+							Resources:   []string{"airways"},
+							Scope:       ptr.To(admissionregistrationv1.ClusterScope),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resourceValidation := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: admissionregistrationv1.SchemeGroupVersion.Identifier(),
+			Kind:       "ValidatingWebhookConfiguration",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "atc-resources",
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name: "resources.yoke.cd",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: cfg.Service.Namespace,
+						Name:      cfg.Service.Name,
+						Path:      ptr.To("/validations/resources"),
+						Port:      &cfg.Service.Port,
+					},
+					CABundle: cfg.Service.CABundle,
+				},
+				SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+				AdmissionReviewVersions: []string{"v1"},
+				FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
+				MatchPolicy:             ptr.To(admissionregistrationv1.Exact),
+				MatchConditions: []admissionregistrationv1.MatchCondition{
+					{
+						Name:       "managed-by-atc",
+						Expression: `object.metadata.labels["app.kubernetes.io/managed-by"] == "atc.yoke" || oldObject.metadata.labels["app.kubernetes.io/managed-by"] == "atc.yoke"`,
+					},
+					{
+						Name: "not-atc-service-account",
+						Expression: fmt.Sprintf(
+							`request.userInfo.username != "system:serviceaccount:%s:%s-service-account"`,
+							cfg.Service.Namespace,
+							cfg.Service.Name,
+						),
+					},
+				},
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Update,
+							admissionregistrationv1.Delete,
+						},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{"*"},
+							APIVersions: []string{"*"},
+							Resources:   []string{"*/*"},
+							Scope:       ptr.To(admissionregistrationv1.AllScopes),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var webhooks []*unstructured.Unstructured
+	for _, webhook := range []*admissionregistrationv1.ValidatingWebhookConfiguration{airwayValidation, resourceValidation} {
+		resource, err := internal.ToUnstructured(webhook)
+		if err != nil {
+			return fmt.Errorf("failed to convert webhook configuration to unstructured representation: %s: %w", webhook.Name, err)
+		}
+		webhooks = append(webhooks, resource)
+	}
+
+	if err := client.ApplyResources(ctx, webhooks, k8s.ApplyResourcesOpts{}); err != nil {
+		return fmt.Errorf("failed to apply webhooks: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/yoke/internal/testing/flights/versioncheck/main.go
+++ b/cmd/yoke/internal/testing/flights/versioncheck/main.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/yokecd/yoke/pkg/flight"
 	"golang.org/x/mod/semver"
+
+	"github.com/yokecd/yoke/pkg/flight"
 )
 
 // let's hope we never reach this version otherwise we break out tests.


### PR DESCRIPTION
DO NOT MERGE.

We've finally run into the issue of why most package manager's don't deal CRDs.

If we merge this, yoke will delete the Airway CRD when upgrading, which can have bad consequences on your ATC.
We may need to adjust the behaviour of takeoff before this is merged.

Possible solutions:
- Make the flight aware of whether we are preserving-crds and fail if not?
- add a preserve-crds flag to takeoff? Default true?
- add the CLI version into the env of the flight so it can guard itself against old versions?