### PR TITLE
yoke/refactor

### DIFF
--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -252,15 +252,17 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 		}
 
 		params := yoke.TakeoffParams{
-			Release:               atc.ReleaseName(&cr),
-			Namespace:             cmp.Or(cr.GetNamespace(), "default"),
-			CrossNamespace:        airway.Spec.CrossNamespace,
-			ClusterAccess:         airway.Spec.ClusterAccess,
-			ClusterResourceAccess: airway.Spec.ResourceAccessMatchers,
-			Flight:                yoke.FlightParams{Input: bytes.NewReader(data)},
-			DryRun:                true,
-			ForceOwnership:        true,
-			ForceConflicts:        true,
+			Release:        atc.ReleaseName(&cr),
+			Namespace:      cmp.Or(cr.GetNamespace(), "default"),
+			CrossNamespace: airway.Spec.CrossNamespace,
+			ClusterAccess: wasi.ClusterAccessParams{
+				Enabled:          airway.Spec.ClusterAccess,
+				ResourceMatchers: airway.Spec.ResourceAccessMatchers,
+			},
+			Flight:         yoke.FlightParams{Input: bytes.NewReader(data)},
+			DryRun:         true,
+			ForceOwnership: true,
+			ForceConflicts: true,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: cr.GetAPIVersion(),

--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -252,16 +253,14 @@ func Handler(client *k8s.Client, cache *wasm.ModuleCache, controllers *atc.Contr
 
 		params := yoke.TakeoffParams{
 			Release:               atc.ReleaseName(&cr),
+			Namespace:             cmp.Or(cr.GetNamespace(), "default"),
 			CrossNamespace:        airway.Spec.CrossNamespace,
 			ClusterAccess:         airway.Spec.ClusterAccess,
 			ClusterResourceAccess: airway.Spec.ResourceAccessMatchers,
-			Flight: yoke.FlightParams{
-				Input:     bytes.NewReader(data),
-				Namespace: cr.GetNamespace(),
-			},
-			DryRun:         true,
-			ForceOwnership: true,
-			ForceConflicts: true,
+			Flight:                yoke.FlightParams{Input: bytes.NewReader(data)},
+			DryRun:                true,
+			ForceOwnership:        true,
+			ForceConflicts:        true,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: cr.GetAPIVersion(),

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -104,15 +104,15 @@ func TestMain(m *testing.M) {
 	ctx := internal.WithDebugFlag(context.Background(), ptr.To(true))
 
 	must(commander.Takeoff(ctx, yoke.TakeoffParams{
-		Release: "atc",
+		Release:   "atc",
+		Namespace: "atc",
 		Flight: yoke.FlightParams{
 			Path: "./test_output/atc-installer.wasm",
 			Input: strings.NewReader(`{
         "image": "yokecd/atc",
         "version": "test"
       }`),
-			Args:      []string{"--skip-version-check"},
-			Namespace: "atc",
+			Args: []string{"--skip-version-check"},
 		},
 		CreateNamespace: true,
 		Wait:            120 * time.Second,
@@ -120,7 +120,8 @@ func TestMain(m *testing.M) {
 	}))
 
 	must(commander.Takeoff(ctx, yoke.TakeoffParams{
-		Release: "wasmcache",
+		Release:   "wasmcache",
+		Namespace: "atc",
 		Flight: yoke.FlightParams{
 			Path: "./test_output/backend.v1.wasm",
 			Input: testutils.JsonReader(backendv1.Backend{
@@ -132,7 +133,6 @@ func TestMain(m *testing.M) {
 					Replicas: 1,
 				},
 			}),
-			Namespace: "atc",
 		},
 		CreateNamespace: true,
 		Wait:            30 * time.Second,
@@ -720,9 +720,9 @@ func TestRestarts(t *testing.T) {
 		t,
 		func() error {
 			if err := commander.Takeoff(ctx, yoke.TakeoffParams{
-				Release: "example",
+				Release:   "example",
+				Namespace: "default",
 				Flight: yoke.FlightParams{
-					Namespace: "default",
 					Input: testutils.JsonReader(backendv1.Backend{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "example",

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -61,7 +61,7 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 	flagset.BoolVar(&params.Lock, "lock", false, "if enabled does locks release before deploying revision (only prevents other locked runs from running).")
 	flagset.BoolVar(&params.CreateNamespace, "create-namespace", false, "create namespace of target release if not present")
 	flagset.BoolVar(&params.CrossNamespace, "cross-namespace", false, "allows releases to create resources in other namespaces than the target namespace")
-	flagset.BoolVar(&params.ClusterAccess, "cluster-access", false, "allows flight access to the cluster during takeoff. Only applies when not directing output to stdout or to a local destination.")
+	flagset.BoolVar(&params.ClusterAccess.Enabled, "cluster-access", false, "allows flight access to the cluster during takeoff. Only applies when not directing output to stdout or to a local destination.")
 	flagset.BoolVar(&params.Flight.Insecure, "insecure", false, "allows image references to be fetched without TLS (only applies to oci urls)")
 
 	flagset.BoolVar(&params.DiffOnly, "diff-only", false, "show diff between current revision and would be applied state. Does not apply anything to cluster")
@@ -80,7 +80,7 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 		"resource-access",
 		"allows flights with cluster-access to read resources outside of the release that match pattern. This flag can be set many times and matchers can be comma separated.",
 		func(s string) error {
-			params.ClusterResourceAccess = append(params.ClusterResourceAccess, strings.Split(s, ",")...)
+			params.ClusterAccess.ResourceMatchers = append(params.ClusterAccess.ResourceMatchers, strings.Split(s, ",")...)
 			return nil
 		},
 	)

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -68,7 +68,7 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 	flagset.BoolVar(&params.Color, "color", term.IsTerminal(int(os.Stdout.Fd())), "use colored output in diffs")
 	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff (ignored if not using --diff-only)")
 	flagset.StringVar(&params.Out, "out", "", "if present outputs flight resources to directory specified, if out is - outputs to standard out")
-	flagset.StringVar(&params.Flight.Namespace, "namespace", "default", "preferred namespace for resources if they do not define one")
+	flagset.StringVar(&params.Namespace, "namespace", "default", "preferred namespace for resources if they do not define one")
 	flagset.DurationVar(&params.Wait, "wait", 0, "time to wait for release to be ready")
 	flagset.DurationVar(&params.Poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
 

--- a/cmd/yoke/main_test.go
+++ b/cmd/yoke/main_test.go
@@ -467,10 +467,10 @@ func TestReleaseOwnershipAcrossNamespaces(t *testing.T) {
 		GlobalSettings: settings,
 		TakeoffParams: yoke.TakeoffParams{
 			Release:        "release",
+			Namespace:      "default",
 			CrossNamespace: true,
 			Flight: yoke.FlightParams{
-				Namespace: "default",
-				Input:     createBasicDeployment(t, "x", "shared"),
+				Input: createBasicDeployment(t, "x", "shared"),
 			},
 		},
 	}))
@@ -481,10 +481,10 @@ func TestReleaseOwnershipAcrossNamespaces(t *testing.T) {
 			GlobalSettings: settings,
 			TakeoffParams: yoke.TakeoffParams{
 				Release:        "release",
+				Namespace:      "shared",
 				CrossNamespace: true,
 				Flight: yoke.FlightParams{
-					Namespace: "shared",
-					Input:     createBasicDeployment(t, "x", "shared"),
+					Input: createBasicDeployment(t, "x", "shared"),
 				},
 			},
 		}),
@@ -505,10 +505,10 @@ func TestReleasesInDifferentNamespaces(t *testing.T) {
 				GlobalSettings: settings,
 				TakeoffParams: yoke.TakeoffParams{
 					Release:         "rel",
+					Namespace:       ns,
 					CreateNamespace: true,
 					Flight: yoke.FlightParams{
-						Input:     createBasicDeployment(t, "release", ""),
-						Namespace: ns,
+						Input: createBasicDeployment(t, "release", ""),
 					},
 				},
 			}),
@@ -538,11 +538,9 @@ func TestTakeoffWithNamespace(t *testing.T) {
 	params := TakeoffParams{
 		GlobalSettings: settings,
 		TakeoffParams: yoke.TakeoffParams{
-			Release: "foo",
-			Flight: yoke.FlightParams{
-				Input:     createBasicDeployment(t, "sample-app", ns),
-				Namespace: ns,
-			},
+			Release:         "foo",
+			Namespace:       ns,
+			Flight:          yoke.FlightParams{Input: createBasicDeployment(t, "sample-app", ns)},
 			CreateNamespace: true,
 		},
 	}
@@ -975,13 +973,11 @@ func TestLookupResource(t *testing.T) {
 		TakeOff(ctx, TakeoffParams{
 			GlobalSettings: settings,
 			TakeoffParams: yoke.TakeoffParams{
-				Release: "foo",
-				Flight: yoke.FlightParams{
-					Path:      "./test_output/flight.wasm",
-					Namespace: "default",
-				},
-				Wait: 10 * time.Second,
-				Poll: time.Second,
+				Release:   "foo",
+				Namespace: "default",
+				Flight:    yoke.FlightParams{Path: "./test_output/flight.wasm"},
+				Wait:      10 * time.Second,
+				Poll:      time.Second,
 			},
 		}),
 		"exit_code(1)",
@@ -993,13 +989,11 @@ func TestLookupResource(t *testing.T) {
 		GlobalSettings: settings,
 		TakeoffParams: yoke.TakeoffParams{
 			Release:       "foo",
+			Namespace:     "default",
 			ClusterAccess: true,
-			Flight: yoke.FlightParams{
-				Path:      "./test_output/flight.wasm",
-				Namespace: "default",
-			},
-			Wait: 10 * time.Second,
-			Poll: time.Second,
+			Flight:        yoke.FlightParams{Path: "./test_output/flight.wasm"},
+			Wait:          10 * time.Second,
+			Poll:          time.Second,
 		},
 	}
 
@@ -1029,12 +1023,12 @@ func TestLookupResource(t *testing.T) {
 			GlobalSettings: settings,
 			TakeoffParams: yoke.TakeoffParams{
 				Release:         "foo",
+				Namespace:       "foo",
 				CreateNamespace: true,
 				ClusterAccess:   true,
 				Flight: yoke.FlightParams{
-					Path:      "./test_output/flight.wasm",
-					Namespace: "foo",
-					Input:     strings.NewReader(`{"Namespace": "default"}`),
+					Path:  "./test_output/flight.wasm",
+					Input: strings.NewReader(`{"Namespace": "default"}`),
 				},
 				Wait: 10 * time.Second,
 				Poll: time.Second,
@@ -1051,13 +1045,13 @@ func TestLookupResource(t *testing.T) {
 			GlobalSettings: settings,
 			TakeoffParams: yoke.TakeoffParams{
 				Release:               "foo",
+				Namespace:             "foo",
 				CreateNamespace:       true,
 				ClusterAccess:         true,
 				ClusterResourceAccess: []string{"default/Configmap"},
 				Flight: yoke.FlightParams{
-					Path:      "./test_output/flight.wasm",
-					Namespace: "foo",
-					Input:     strings.NewReader(`{"Namespace": "default"}`),
+					Path:  "./test_output/flight.wasm",
+					Input: strings.NewReader(`{"Namespace": "default"}`),
 				},
 				Wait: 10 * time.Second,
 				Poll: time.Second,
@@ -1074,13 +1068,13 @@ func TestLookupResource(t *testing.T) {
 			GlobalSettings: settings,
 			TakeoffParams: yoke.TakeoffParams{
 				Release:               "foo",
+				Namespace:             "foo",
 				CreateNamespace:       true,
 				ClusterAccess:         true,
 				ClusterResourceAccess: []string{"default/*", "foo/*"},
 				Flight: yoke.FlightParams{
-					Path:      "./test_output/flight.wasm",
-					Namespace: "foo",
-					Input:     strings.NewReader(`{"Namespace": "default"}`),
+					Path:  "./test_output/flight.wasm",
+					Input: strings.NewReader(`{"Namespace": "default"}`),
 				},
 				Wait: 10 * time.Second,
 				Poll: time.Second,
@@ -1099,13 +1093,11 @@ func TestBadVersion(t *testing.T) {
 	err := TakeOff(ctx, TakeoffParams{
 		GlobalSettings: settings,
 		TakeoffParams: yoke.TakeoffParams{
-			Release: "foo",
-			Flight: yoke.FlightParams{
-				Path:      "./test_output/flight.wasm",
-				Namespace: "default",
-			},
-			Wait: 10 * time.Second,
-			Poll: time.Second,
+			Release:   "foo",
+			Namespace: "default",
+			Flight:    yoke.FlightParams{Path: "./test_output/flight.wasm"},
+			Wait:      10 * time.Second,
+			Poll:      time.Second,
 		},
 	})
 	require.ErrorContains(t, err, "exit_code(1)")

--- a/cmd/yoke/main_test.go
+++ b/cmd/yoke/main_test.go
@@ -990,7 +990,7 @@ func TestLookupResource(t *testing.T) {
 		TakeoffParams: yoke.TakeoffParams{
 			Release:       "foo",
 			Namespace:     "default",
-			ClusterAccess: true,
+			ClusterAccess: yoke.ClusterAccessParams{Enabled: true},
 			Flight:        yoke.FlightParams{Path: "./test_output/flight.wasm"},
 			Wait:          10 * time.Second,
 			Poll:          time.Second,
@@ -1025,7 +1025,7 @@ func TestLookupResource(t *testing.T) {
 				Release:         "foo",
 				Namespace:       "foo",
 				CreateNamespace: true,
-				ClusterAccess:   true,
+				ClusterAccess:   yoke.ClusterAccessParams{Enabled: true},
 				Flight: yoke.FlightParams{
 					Path:  "./test_output/flight.wasm",
 					Input: strings.NewReader(`{"Namespace": "default"}`),
@@ -1044,11 +1044,10 @@ func TestLookupResource(t *testing.T) {
 		TakeOff(ctx, TakeoffParams{
 			GlobalSettings: settings,
 			TakeoffParams: yoke.TakeoffParams{
-				Release:               "foo",
-				Namespace:             "foo",
-				CreateNamespace:       true,
-				ClusterAccess:         true,
-				ClusterResourceAccess: []string{"default/Configmap"},
+				Release:         "foo",
+				Namespace:       "foo",
+				CreateNamespace: true,
+				ClusterAccess:   yoke.ClusterAccessParams{Enabled: true, ResourceMatchers: []string{"default/Configmap"}},
 				Flight: yoke.FlightParams{
 					Path:  "./test_output/flight.wasm",
 					Input: strings.NewReader(`{"Namespace": "default"}`),
@@ -1067,11 +1066,13 @@ func TestLookupResource(t *testing.T) {
 		TakeOff(ctx, TakeoffParams{
 			GlobalSettings: settings,
 			TakeoffParams: yoke.TakeoffParams{
-				Release:               "foo",
-				Namespace:             "foo",
-				CreateNamespace:       true,
-				ClusterAccess:         true,
-				ClusterResourceAccess: []string{"default/*", "foo/*"},
+				Release:         "foo",
+				Namespace:       "foo",
+				CreateNamespace: true,
+				ClusterAccess: yoke.ClusterAccessParams{
+					Enabled:          true,
+					ResourceMatchers: []string{"default/*", "foo/*"},
+				},
 				Flight: yoke.FlightParams{
 					Path:  "./test_output/flight.wasm",
 					Input: strings.NewReader(`{"Namespace": "default"}`),

--- a/cmd/yokecd/internal/plugin/run_e2e_test.go
+++ b/cmd/yokecd/internal/plugin/run_e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/cmd/yokecd/internal/svr/run.go
+++ b/cmd/yokecd/internal/svr/run.go
@@ -164,10 +164,12 @@ func Handler(ttl time.Duration, mods *xsync.Map[string, *Mod], logger *slog.Logg
 				}
 
 				output, _, err := yoke.EvalFlight(r.Context(), yoke.EvalParams{
-					Client:    nil,
+					Client:        nil,
+					ClusterAccess: yoke.ClusterAccessParams{
+						// TODO
+					},
 					Release:   ex.Release,
 					Namespace: ex.Namespace,
-					Matchers:  []string{},
 					Flight: yoke.FlightParams{
 						Module: yoke.Module{Instance: mod.Instance},
 						Args:   ex.Args,

--- a/cmd/yokecd/internal/svr/run.go
+++ b/cmd/yokecd/internal/svr/run.go
@@ -164,15 +164,15 @@ func Handler(ttl time.Duration, mods *xsync.Map[string, *Mod], logger *slog.Logg
 				}
 
 				output, _, err := yoke.EvalFlight(r.Context(), yoke.EvalParams{
-					Client:   nil,
-					Release:  ex.Release,
-					Matchers: []string{},
+					Client:    nil,
+					Release:   ex.Release,
+					Namespace: ex.Namespace,
+					Matchers:  []string{},
 					Flight: yoke.FlightParams{
-						Module:    yoke.Module{Instance: mod.Instance},
-						Args:      ex.Args,
-						Env:       ex.Env,
-						Namespace: ex.Namespace,
-						Input:     strings.NewReader(ex.Input),
+						Module: yoke.Module{Instance: mod.Instance},
+						Args:   ex.Args,
+						Env:    ex.Env,
+						Input:  strings.NewReader(ex.Input),
 					},
 				})
 				return output, err

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -734,11 +734,9 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 		var identity *unstructured.Unstructured
 
 		takeoffParams := yoke.TakeoffParams{
-			Release: release,
-			Flight: yoke.FlightParams{
-				Input:     bytes.NewReader(data),
-				Namespace: event.Namespace,
-			},
+			Release:               release,
+			Namespace:             event.Namespace,
+			Flight:                yoke.FlightParams{Input: bytes.NewReader(data)},
 			ManagedBy:             "atc.yoke",
 			Lock:                  false,
 			ForceConflicts:        true,

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -289,7 +289,7 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 			}
 			mod, err := wasi.Compile(ctx, wasi.CompileParams{
 				Wasm:           data,
-				LookupResource: wasi.HostLookupResource(ctrl.Client(ctx), typedAirway.Spec.ResourceAccessMatchers),
+				LookupResource: wasi.HostLookupResource(ctrl.Client(ctx)),
 			})
 			if err != nil {
 				return fmt.Errorf("failed to compile wasm: %w", err)
@@ -734,17 +734,19 @@ func (atc atc) FlightReconciler(params FlightReconcilerParams) ctrl.HandleFunc {
 		var identity *unstructured.Unstructured
 
 		takeoffParams := yoke.TakeoffParams{
-			Release:               release,
-			Namespace:             event.Namespace,
-			Flight:                yoke.FlightParams{Input: bytes.NewReader(data)},
-			ManagedBy:             "atc.yoke",
-			Lock:                  false,
-			ForceConflicts:        true,
-			ForceOwnership:        true,
-			HistoryCapSize:        cmp.Or(params.Airway.Spec.HistoryCapSize, 2),
-			ClusterAccess:         params.Airway.Spec.ClusterAccess,
-			ClusterResourceAccess: params.Airway.Spec.ResourceAccessMatchers,
-			CrossNamespace:        params.Airway.Spec.CrossNamespace,
+			Release:        release,
+			Namespace:      event.Namespace,
+			Flight:         yoke.FlightParams{Input: bytes.NewReader(data)},
+			ManagedBy:      "atc.yoke",
+			Lock:           false,
+			ForceConflicts: true,
+			ForceOwnership: true,
+			HistoryCapSize: cmp.Or(params.Airway.Spec.HistoryCapSize, 2),
+			ClusterAccess: yoke.ClusterAccessParams{
+				Enabled:          params.Airway.Spec.ClusterAccess,
+				ResourceMatchers: params.Airway.Spec.ResourceAccessMatchers,
+			},
+			CrossNamespace: params.Airway.Spec.CrossNamespace,
 			PruneOpts: k8s.PruneOpts{
 				RemoveCRDs:       params.Airway.Spec.Prune.CRDs,
 				RemoveNamespaces: params.Airway.Spec.Prune.Namespaces,

--- a/internal/wasi/host.go
+++ b/internal/wasi/host.go
@@ -1,0 +1,92 @@
+package wasi
+
+import (
+	"cmp"
+	"context"
+	"errors"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/yokecd/yoke/internal"
+	"github.com/yokecd/yoke/internal/k8s"
+)
+
+type HostLookupResourceFunc func(ctx context.Context, name, namespace, kind, apiVersion string) (*unstructured.Unstructured, error)
+
+var ErrFeatureNotGranted = errors.New("feature not granted")
+
+func HostLookupResource(client *k8s.Client) HostLookupResourceFunc {
+	return func(ctx context.Context, name, namespace, kind, apiVersion string) (*unstructured.Unstructured, error) {
+		clusterAccess := clusterAccessEnabled(ctx)
+		if !clusterAccess.Enabled {
+			return nil, ErrFeatureNotGranted
+		}
+
+		gv, err := schema.ParseGroupVersion(apiVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		mapping, err := client.Mapper.RESTMapping(schema.GroupKind{Group: gv.Group, Kind: kind}, gv.Version)
+		if err != nil {
+			return nil, err
+		}
+
+		intf := func() dynamic.ResourceInterface {
+			intf := client.Dynamic.Resource(mapping.Resource)
+			if mapping.Scope == meta.RESTScopeNamespace {
+				return intf.Namespace(cmp.Or(namespace, "default"))
+			}
+			return intf
+		}()
+
+		resource, err := intf.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, matcher := range clusterAccess.ResourceMatchers {
+			if internal.MatchResource(resource, matcher) {
+				return resource, nil
+			}
+		}
+
+		if internal.GetOwner(resource) != getOwner(ctx) {
+			return nil, kerrors.NewForbidden(schema.GroupResource{}, "", errors.New("cannot access resource outside of target release ownership"))
+		}
+
+		return resource, nil
+	}
+}
+
+type ownerKey struct{}
+
+func WithOwner(ctx context.Context, owner string) context.Context {
+	return context.WithValue(ctx, ownerKey{}, owner)
+}
+
+func getOwner(ctx context.Context) string {
+	value, _ := ctx.Value(ownerKey{}).(string)
+	return value
+}
+
+type clusterAccessKey struct{}
+
+type ClusterAccessParams struct {
+	Enabled          bool
+	ResourceMatchers []string
+}
+
+func WithClusterAccess(ctx context.Context, access ClusterAccessParams) context.Context {
+	return context.WithValue(ctx, clusterAccessKey{}, access)
+}
+
+func clusterAccessEnabled(ctx context.Context) ClusterAccessParams {
+	value, _ := ctx.Value(clusterAccessKey{}).(ClusterAccessParams)
+	return value
+}

--- a/pkg/yoke/wasm.go
+++ b/pkg/yoke/wasm.go
@@ -103,10 +103,11 @@ func gzipReader(r io.Reader) io.Reader {
 }
 
 type EvalParams struct {
-	Client   *k8s.Client
-	Release  string
-	Matchers []string
-	Flight   FlightParams
+	Client    *k8s.Client
+	Release   string
+	Namespace string
+	Matchers  []string
+	Flight    FlightParams
 }
 
 func EvalFlight(ctx context.Context, params EvalParams) ([]byte, []byte, error) {
@@ -127,8 +128,8 @@ func EvalFlight(ctx context.Context, params EvalParams) ([]byte, []byte, error) 
 
 	yokeEnvVars := map[string]string{
 		"YOKE_RELEASE":   params.Release,
-		"YOKE_NAMESPACE": params.Flight.Namespace,
-		"NAMESPACE":      params.Flight.Namespace,
+		"YOKE_NAMESPACE": params.Namespace,
+		"NAMESPACE":      params.Namespace,
 		"YOKE_VERSION":   internal.Version(),
 	}
 

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -110,10 +110,8 @@ type TakeoffParams struct {
 	OwnerReferences []metav1.OwnerReference
 
 	// ClusterAccess grants the flight access to the kubernetes cluster. Users will be able to use the host k8s_lookup function.
-	ClusterAccess bool
-
-	// ClusterResourceAccess
-	ClusterResourceAccess []string
+	// This includes enabling/disabling cluster-access and granting any external resource matchers.
+	ClusterAccess ClusterAccessParams
 
 	// HistoryCapSize limits the number of revisions kept in the release's history by the size. If Cap is less than 1 history is uncapped.
 	HistoryCapSize int
@@ -143,16 +141,11 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) (e
 	output, wasm, err := EvalFlight(
 		ctx,
 		EvalParams{
-			Client: func() *k8s.Client {
-				if !params.ClusterAccess {
-					return nil
-				}
-				return commander.k8s
-			}(),
-			Release:   params.Release,
-			Namespace: params.Namespace,
-			Matchers:  params.ClusterResourceAccess,
-			Flight:    params.Flight,
+			Client:        commander.k8s,
+			Release:       params.Release,
+			Namespace:     params.Namespace,
+			ClusterAccess: params.ClusterAccess,
+			Flight:        params.Flight,
 		},
 	)
 	if err != nil {

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -40,7 +40,6 @@ type FlightParams struct {
 	Insecure            bool
 	Module              Module
 	Args                []string
-	Namespace           string
 	CompilationCacheDir string
 
 	// Env specifies user-defined envvars to be added to the flight execution.
@@ -77,6 +76,9 @@ type TakeoffParams struct {
 
 	// Name of release
 	Release string
+
+	// Release Namespace
+	Namespace string
 
 	// Out is a folder to which to write all the resources hierarchically. This does not create a release or apply any state to the cluster.
 	// This is useful for debugging/inspecting output or for working CDK8s style using kubectl apply --recursive.
@@ -147,9 +149,10 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) (e
 				}
 				return commander.k8s
 			}(),
-			Release:  params.Release,
-			Matchers: params.ClusterResourceAccess,
-			Flight:   params.Flight,
+			Release:   params.Release,
+			Namespace: params.Namespace,
+			Matchers:  params.ClusterResourceAccess,
+			Flight:    params.Flight,
 		},
 	)
 	if err != nil {
@@ -184,7 +187,7 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) (e
 		}
 	}
 
-	targetNS := cmp.Or(params.Flight.Namespace, "default")
+	targetNS := cmp.Or(params.Namespace, "default")
 	for _, stage := range stages {
 		internal.AddYokeMetadata(stage, params.Release, targetNS, params.ManagedBy)
 	}


### PR DESCRIPTION
- **pkg/yoke: refactor EvalParams to use namespace directly instead of passing via flightParams**
- **internal/wasi: refactor to make cluster-access contextual to the host module**
