### PR TITLE
atc: add subscription mode

### DIFF
--- a/cmd/atc/internal/testing/Dockerfile.wasmcache
+++ b/cmd/atc/internal/testing/Dockerfile.wasmcache
@@ -22,6 +22,7 @@ RUN \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/prune.wasm ./cmd/atc/internal/testing/flights/prune && \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/externalcreation.wasm ./cmd/atc/internal/testing/flights/externalcreation && \
   GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/timeout.wasm ./cmd/atc/internal/testing/flights/timeout && \
+  GOOS=wasip1 GOARCH=wasm go build -o ./cmd/atc/internal/testing/wasmcache/wasm/subscriptions.wasm ./cmd/atc/internal/testing/flights/subscriptions && \
   go build -o ./bin/server ./cmd/atc/internal/testing/wasmcache
 
 FROM alpine

--- a/cmd/atc/internal/testing/flights/subscriptions/main.go
+++ b/cmd/atc/internal/testing/flights/subscriptions/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/yokecd/yoke/pkg/flight"
+	"github.com/yokecd/yoke/pkg/flight/wasi/k8s"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	subscribed := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "subscribed",
+		},
+	}
+
+	if _, err := k8s.LookupResource(subscribed); err != nil && !k8s.IsErrNotFound(err) {
+		return fmt.Errorf("failed to lookup resource we want to subscribe to: %w", err)
+	}
+
+	standard := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "standard",
+		},
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(flight.Resources{subscribed, standard})
+}

--- a/internal/xsync/set.go
+++ b/internal/xsync/set.go
@@ -1,7 +1,9 @@
 package xsync
 
 import (
+	"fmt"
 	"iter"
+	"slices"
 	"sync"
 )
 
@@ -11,14 +13,55 @@ func (set *Set[T]) Add(elem T) {
 	(*sync.Map)(set).Store(elem, struct{}{})
 }
 
+func (set *Set[T]) Has(elem T) bool {
+	if set == nil {
+		return false
+	}
+	_, ok := (*sync.Map)(set).Load(elem)
+	return ok
+}
+
+func (set *Set[T]) Union(src *Set[T]) *Set[T] {
+	var result Set[T]
+	for item := range set.All() {
+		result.Add(item)
+	}
+	for item := range src.All() {
+		result.Add(item)
+	}
+	return &result
+}
+
+func (set *Set[T]) Intersection(src *Set[T]) *Set[T] {
+	var result Set[T]
+	for item := range set.All() {
+		if src.Has(item) {
+			result.Add(item)
+		}
+	}
+	for item := range src.All() {
+		if set.Has(item) {
+			result.Add(item)
+		}
+	}
+	return &result
+}
+
 func (set *Set[T]) Del(elem T) {
 	(*sync.Map)(set).Delete(elem)
 }
 
 func (set *Set[T]) All() iter.Seq[T] {
 	return func(yield func(T) bool) {
+		if set == nil {
+			return
+		}
 		(*sync.Map)(set).Range(func(key, value any) bool {
 			return yield(key.(T))
 		})
 	}
+}
+
+func (set *Set[T]) String() string {
+	return fmt.Sprint(slices.Collect(set.All()))
 }

--- a/pkg/apis/airway/v1alpha1/airway.go
+++ b/pkg/apis/airway/v1alpha1/airway.go
@@ -56,14 +56,15 @@ func (AirwayMode) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
 }
 
 const (
-	AirwayModeStandard AirwayMode = "standard"
-	AirwayModeStatic   AirwayMode = "static"
-	AirwayModeDynamic  AirwayMode = "dynamic"
+	AirwayModeStandard     AirwayMode = "standard"
+	AirwayModeStatic       AirwayMode = "static"
+	AirwayModeDynamic      AirwayMode = "dynamic"
+	AirwayModeSubscription AirwayMode = "subscription"
 )
 
 // Modes returns the list of known Airway modes.
 func Modes() []AirwayMode {
-	return []AirwayMode{AirwayModeStandard, AirwayModeStatic, AirwayModeDynamic}
+	return []AirwayMode{AirwayModeStandard, AirwayModeStatic, AirwayModeDynamic, AirwayModeSubscription}
 }
 
 type AirwaySpec struct {

--- a/pkg/openapi/flight.golden.json
+++ b/pkg/openapi/flight.golden.json
@@ -37,7 +37,8 @@
           "enum": [
             "standard",
             "static",
-            "dynamic"
+            "dynamic",
+            "subscription"
           ]
         },
         "objectPath": {

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -27,6 +27,7 @@ import (
 	"github.com/yokecd/yoke/internal/k8s"
 	"github.com/yokecd/yoke/internal/text"
 	"github.com/yokecd/yoke/internal/wasi"
+	"github.com/yokecd/yoke/internal/wasi/host"
 )
 
 type ModuleSourcetadata = internal.Source
@@ -387,6 +388,10 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) (e
 			return internal.Warning(fmt.Sprintf("failed to cap release history after successful takeoff of %s: %v", params.Release, err))
 		}
 	}
+
+	// If the context of ReleaseTracking from the ATC, we may want to capture the resources that were deployed.
+	// This is only used in SubscriptionMode for airways. Otherwise has no effect.
+	host.SetReleaseResources(ctx, stages.Flatten())
 
 	fmt.Fprintf(internal.Stderr(ctx), "successful takeoff of %s\n", params.Release)
 


### PR DESCRIPTION
This PR adds a new AirwayMode: `Subscription`.

This mode is similar to dynamic mode but only resources that have been subscribed to (via a kubernetes lookup) trigger re-evaluations of the instance.