### PR TITLE
yoke: support yoke version when yoke is used a dependency

### DIFF
--- a/cmd/yoke/cmd_version.go
+++ b/cmd/yoke/cmd_version.go
@@ -1,19 +1,20 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"slices"
+	"runtime/debug"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/yokecd/yoke/internal"
 )
 
-func Version() error {
+func Version(ctx context.Context) error {
 	tbl := table.NewWriter()
 	tbl.SetStyle(table.StyleRounded)
 
-	tbl.AppendRow(table.Row{"yoke", internal.Info.Main.Version})
+	tbl.AppendRow(table.Row{"yoke", internal.GetYokeVersion()})
 	tbl.AppendRow(table.Row{"toolchain", internal.Info.GoVersion})
 
 	modules := []string{
@@ -21,15 +22,14 @@ func Version() error {
 		"github.com/tetratelabs/wazero",
 	}
 
-	slices.Sort(modules)
-
-	for _, mod := range internal.Info.Deps {
-		if slices.Contains(modules, mod.Path) {
-			tbl.AppendRow(table.Row{mod.Path, mod.Version})
+	for _, modPath := range modules {
+		mod, ok := internal.Find(internal.Info.Deps, func(mod *debug.Module) bool { return mod.Path == modPath })
+		if !ok {
+			continue
 		}
+		tbl.AppendRow(table.Row{mod.Path, mod.Version})
 	}
 
-	fmt.Println(tbl.Render())
-
-	return nil
+	_, err := fmt.Fprintln(internal.Stdout(ctx), tbl.Render())
+	return err
 }

--- a/cmd/yoke/main.go
+++ b/cmd/yoke/main.go
@@ -137,7 +137,7 @@ func run() error {
 
 	case "version":
 		{
-			return Version()
+			return Version(ctx)
 		}
 	default:
 		return fmt.Errorf("unknown command: %s", cmd)

--- a/internal/debug.go
+++ b/internal/debug.go
@@ -31,3 +31,16 @@ func DebugTimer(ctx context.Context, msg string) func() {
 }
 
 var Info, _ = debug.ReadBuildInfo()
+
+func GetYokeVersion() string {
+	const path = "github.com/yokecd/yoke"
+	if Info.Main.Path == path {
+		return Info.Main.Version
+	}
+	for _, dep := range Info.Deps {
+		if dep.Path == path {
+			return dep.Version
+		}
+	}
+	return "(unknown?)"
+}

--- a/pkg/yoke/wasm.go
+++ b/pkg/yoke/wasm.go
@@ -133,7 +133,7 @@ func EvalFlight(ctx context.Context, params EvalParams) ([]byte, []byte, error) 
 		"YOKE_RELEASE":   params.Release,
 		"YOKE_NAMESPACE": params.Namespace,
 		"NAMESPACE":      params.Namespace,
-		"YOKE_VERSION":   internal.Info.Main.Version,
+		"YOKE_VERSION":   internal.GetYokeVersion(),
 	}
 
 	env := map[string]string{}

--- a/pkg/yoke/yoke_schematics_test.go
+++ b/pkg/yoke/yoke_schematics_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/yokecd/yoke/internal/x"
 )
 


### PR DESCRIPTION
This PR fixes a bug where the YOKE_VERSION was not properly set when yoke was used as module via its public Go SDK.