### PR TITLE
atc-installer: configure validation webhook timeout

### DIFF
--- a/cmd/atc-installer/installer/run.go
+++ b/cmd/atc-installer/installer/run.go
@@ -32,9 +32,11 @@ type Config struct {
 	ImagePullPolicy           corev1.PullPolicy `json:"imagePullPolicy,omitzero"`
 	GenerateTLS               bool              `json:"generateTLS,omitzero" Description:"generate new tls certificates even if they already exist"`
 	DockerConfigSecretName    string            `json:"dockerConfigSecretName,omitzero" Description:"name of dockerconfig secret to allow atc to pull images from private registries"`
-	LogFormat                 string            `json:"logFormat,omitzero" Enum:"json,text"`
-	Verbose                   bool              `json:"verbose,omitzero" Description:"verbose logging"`
-	ValidationWebhookTimeout  int               `json:"validationWebhookTimeout,omitzero" Description:"timeout in seconds for validation webhooks (default: 10)"`
+	LogFormat                          string `json:"logFormat,omitzero" Enum:"json,text"`
+	Verbose                            bool   `json:"verbose,omitzero" Description:"verbose logging"`
+	AirwayValidationWebhookTimeout     int    `json:"airwayValidationWebhookTimeout,omitzero" Description:"timeout in seconds for airway instance validation webhooks (default: 10)"`
+	ResourceValidationWebhookTimeout   int    `json:"resourceValidationWebhookTimeout,omitzero" Description:"timeout in seconds for resource/event dispatching validation webhooks (default: 5)"`
+	ExternalResourceValidationWebhookTimeout int `json:"externalResourceValidationWebhookTimeout,omitzero" Description:"timeout in seconds for external resource validation webhooks (default: 30)"`
 }
 
 func Run(cfg Config) (flight.Resources, error) {
@@ -223,10 +225,22 @@ func Run(cfg Config) (flight.Resources, error) {
 									{Name: "LOG_FORMAT", Value: cfg.LogFormat},
 									{Name: "VERBOSE", Value: strconv.FormatBool(cfg.Verbose)},
 								}
-								if cfg.ValidationWebhookTimeout > 0 {
+								if cfg.AirwayValidationWebhookTimeout > 0 {
 									env = append(env, corev1.EnvVar{
-										Name:  "VALIDATION_WEBHOOK_TIMEOUT",
-										Value: strconv.Itoa(cfg.ValidationWebhookTimeout),
+										Name:  "AIRWAY_VALIDATION_WEBHOOK_TIMEOUT",
+										Value: strconv.Itoa(cfg.AirwayValidationWebhookTimeout),
+									})
+								}
+								if cfg.ResourceValidationWebhookTimeout > 0 {
+									env = append(env, corev1.EnvVar{
+										Name:  "RESOURCE_VALIDATION_WEBHOOK_TIMEOUT",
+										Value: strconv.Itoa(cfg.ResourceValidationWebhookTimeout),
+									})
+								}
+								if cfg.ExternalResourceValidationWebhookTimeout > 0 {
+									env = append(env, corev1.EnvVar{
+										Name:  "EXTERNAL_RESOURCE_VALIDATION_WEBHOOK_TIMEOUT",
+										Value: strconv.Itoa(cfg.ExternalResourceValidationWebhookTimeout),
 									})
 								}
 								return env

--- a/cmd/atc/config.go
+++ b/cmd/atc/config.go
@@ -20,7 +20,9 @@ type Config struct {
 
 	Verbose bool
 
-	ValidationWebhookTimeout int32
+	AirwayValidationWebhookTimeout     int32
+	ResourceValidationWebhookTimeout   int32
+	ExternalResourceValidationWebhookTimeout int32
 
 	TLS TLSConfig
 }
@@ -57,7 +59,9 @@ func LoadConfig() (*Config, error) {
 
 	conf.Var(parser, &cfg.Verbose, "VERBOSE")
 
-	conf.Var(parser, &cfg.ValidationWebhookTimeout, "VALIDATION_WEBHOOK_TIMEOUT")
+	conf.Var(parser, &cfg.AirwayValidationWebhookTimeout, "AIRWAY_VALIDATION_WEBHOOK_TIMEOUT")
+	conf.Var(parser, &cfg.ResourceValidationWebhookTimeout, "RESOURCE_VALIDATION_WEBHOOK_TIMEOUT")
+	conf.Var(parser, &cfg.ExternalResourceValidationWebhookTimeout, "EXTERNAL_RESOURCE_VALIDATION_WEBHOOK_TIMEOUT")
 
 	if err := parser.Parse(); err != nil {
 		return nil, err

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -117,7 +117,7 @@ func run() (err error) {
 
 	airwayGK := schema.GroupKind{Group: "yoke.cd", Kind: "Airway"}
 
-	reconciler, teardown := atc.GetReconciler(cfg.Service, moduleCache, controllers, eventDispatcher, cfg.Concurrency, cfg.ValidationWebhookTimeout)
+	reconciler, teardown := atc.GetReconciler(cfg.Service, moduleCache, controllers, eventDispatcher, cfg.Concurrency, cfg.AirwayValidationWebhookTimeout)
 	defer teardown()
 
 	controller, err := ctrl.NewController(ctx, ctrl.Params{

--- a/cmd/atc/resources.go
+++ b/cmd/atc/resources.go
@@ -92,12 +92,28 @@ func ApplyResources(ctx context.Context, client *k8s.Client, cfg *Config) error 
 		return fmt.Errorf("failed to apply airway crd: %w", err)
 	}
 
-	// Get timeout value, defaulting to 10 seconds if not configured
-	timeoutSeconds := func() *int32 {
-		if cfg.ValidationWebhookTimeout > 0 {
-			return ptr.To(cfg.ValidationWebhookTimeout)
+	// Get timeout value for airway validation webhook, defaulting to 10 seconds if not configured
+	airwayTimeoutSeconds := func() *int32 {
+		if cfg.AirwayValidationWebhookTimeout > 0 {
+			return ptr.To(cfg.AirwayValidationWebhookTimeout)
 		}
 		return ptr.To[int32](10)
+	}()
+
+	// Get timeout value for resource validation webhook (event dispatching), defaulting to 5 seconds if not configured
+	resourceTimeoutSeconds := func() *int32 {
+		if cfg.ResourceValidationWebhookTimeout > 0 {
+			return ptr.To(cfg.ResourceValidationWebhookTimeout)
+		}
+		return ptr.To[int32](5)
+	}()
+
+	// Get timeout value for external resource validation webhook, defaulting to 30 seconds if not configured
+	externalResourceTimeoutSeconds := func() *int32 {
+		if cfg.ExternalResourceValidationWebhookTimeout > 0 {
+			return ptr.To(cfg.ExternalResourceValidationWebhookTimeout)
+		}
+		return ptr.To[int32](30)
 	}()
 
 	airwayValidation := &admissionregistrationv1.ValidatingWebhookConfiguration{
@@ -122,7 +138,7 @@ func ApplyResources(ctx context.Context, client *k8s.Client, cfg *Config) error 
 				},
 				SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
 				AdmissionReviewVersions: []string{"v1"},
-				TimeoutSeconds:          timeoutSeconds,
+				TimeoutSeconds:          airwayTimeoutSeconds,
 				Rules: []admissionregistrationv1.RuleWithOperations{
 					{
 						Operations: []admissionregistrationv1.OperationType{
@@ -165,7 +181,7 @@ func ApplyResources(ctx context.Context, client *k8s.Client, cfg *Config) error 
 				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
 				MatchPolicy:             ptr.To(admissionregistrationv1.Exact),
-				TimeoutSeconds:          timeoutSeconds,
+				TimeoutSeconds:          resourceTimeoutSeconds,
 				MatchConditions: []admissionregistrationv1.MatchCondition{
 					{
 						Name:       "managed-by-atc",
@@ -222,7 +238,7 @@ func ApplyResources(ctx context.Context, client *k8s.Client, cfg *Config) error 
 				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
 				MatchPolicy:             ptr.To(admissionregistrationv1.Exact),
-				TimeoutSeconds:          timeoutSeconds,
+				TimeoutSeconds:          externalResourceTimeoutSeconds,
 				MatchConditions: []admissionregistrationv1.MatchCondition{
 					{
 						Name: "all",

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -68,7 +68,7 @@ func (controller Controller) FlightState(name, ns string) (FlightState, bool) {
 
 type ControllerCache = xsync.Map[string, Controller]
 
-func GetReconciler(service ServiceDef, cache *wasm.ModuleCache, controllers *ControllerCache, dispatcher *EventDispatcher, concurrency int, validationWebhookTimeout int32) (ctrl.HandleFunc, func()) {
+func GetReconciler(service ServiceDef, cache *wasm.ModuleCache, controllers *ControllerCache, dispatcher *EventDispatcher, concurrency int, airwayValidationWebhookTimeout int32) (ctrl.HandleFunc, func()) {
 	atc := atc{
 		concurrency:              concurrency,
 		service:                   service,
@@ -76,7 +76,7 @@ func GetReconciler(service ServiceDef, cache *wasm.ModuleCache, controllers *Con
 		moduleCache:               cache,
 		controllers:               controllers,
 		dispatcher:                dispatcher,
-		validationWebhookTimeout:  validationWebhookTimeout,
+		validationWebhookTimeout:  airwayValidationWebhookTimeout,
 	}
 	return atc.Reconcile, atc.Teardown
 }


### PR DESCRIPTION
Add support for configuring validation webhook timeout when installing the ATC.

- Add ValidationWebhookTimeout field to installer Config
- Pass timeout as VALIDATION_WEBHOOK_TIMEOUT environment variable
- Load timeout from env var in ATC config
- Apply timeout to all validation webhooks (default: 10s)

Fixes #129