### PR TITLE
refactor

### DIFF
--- a/internal/k8s/ctrl/controller.go
+++ b/internal/k8s/ctrl/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/rand/v2"
 	"sync"
@@ -236,6 +237,7 @@ func (instance *Instance) Run() error {
 						ctx = context.WithValue(ctx, loggerKey{}, logger)
 						ctx = context.WithValue(ctx, clientKey{}, instance.Client)
 						ctx = context.WithValue(ctx, instanceKey{}, instance)
+						ctx = internal.WithStdio(ctx, io.Discard, io.Discard, internal.Stdin(ctx))
 
 						logger.Info("processing event")
 


### PR DESCRIPTION
The PR refactors the ATC reconcilers to use `apimachinery` meta api to handle conditions instead of custom code.
It also removes extraneous logs from the ATC generated by the underlying yoke sdk as if it were talking to a CLI.