### PR TITLE
yoke: breaking change: use context namespace as default namespace when running yoke

### DIFF
--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -74,7 +74,7 @@ func run() (err error) {
 		return fmt.Errorf("failed to get kubeconfig: %w", err)
 	}
 
-	client, err := k8s.NewClient(kubecfg)
+	client, err := k8s.NewClient(kubecfg, "")
 	if err != nil {
 		return fmt.Errorf("failed to instantiate kubernetes client: %w", err)
 	}

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -1011,7 +1011,9 @@ func TestClusterScopeDynamicAirway(t *testing.T) {
 	)
 
 	for _, ns := range []string{"foo", "bar"} {
-		require.NoError(t, client.Clientset.CoreV1().ConfigMaps(ns).Delete(context.Background(), "cm", metav1.DeleteOptions{}))
+		if err := client.Clientset.CoreV1().ConfigMaps(ns).Delete(context.Background(), "cm", metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+			require.NoError(t, err)
+		}
 	}
 
 	testutils.EventuallyNoErrorf(
@@ -3023,7 +3025,7 @@ func TestOverridePermissions(t *testing.T) {
 		UserName: "system:serviceaccount:default:" + sa.Name,
 	}
 
-	saClient, err := k8s.NewClient(restCfg)
+	saClient, err := k8s.NewClient(restCfg, "")
 	require.NoError(t, err)
 
 	ctx := internal.WithDebugFlag(context.Background(), func(value bool) *bool { return &value }(true))

--- a/cmd/yoke/cmd_descent.go
+++ b/cmd/yoke/cmd_descent.go
@@ -39,7 +39,7 @@ func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, 
 
 	RegisterGlobalFlags(flagset, &params.GlobalSettings)
 
-	flagset.StringVar(&params.Namespace, "namespace", "default", "target namespace of release")
+	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
 	flagset.DurationVar(&params.Wait, "wait", 0, "time to wait for release to become ready")
 	flagset.DurationVar(&params.Poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
 	flagset.BoolVar(&params.Lock, "lock", false, "if enabled does locks release before deploying revision (only prevents other locked runs from running).")

--- a/cmd/yoke/cmd_mayday.go
+++ b/cmd/yoke/cmd_mayday.go
@@ -35,7 +35,7 @@ func GetMaydayParams(settings GlobalSettings, args []string) (*MaydayParams, err
 
 	RegisterGlobalFlags(flagset, &params.GlobalSettings)
 
-	flagset.StringVar(&params.Namespace, "namespace", "default", "target namespace of release to remove")
+	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
 
 	var removeAll bool
 	flagset.BoolVar(&removeAll, "remove-all", false, "deletes crds and namespaces owned by the release. Destructive and dangerous use with caution.")

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -70,7 +70,7 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 	flagset.BoolVar(&params.Color, "color", term.IsTerminal(int(os.Stdout.Fd())), "use colored output in diffs")
 	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff (ignored if not using --diff-only)")
 	flagset.StringVar(&params.Out, "out", "", "if present outputs flight resources to directory specified, if out is - outputs to standard out")
-	flagset.StringVar(&params.Namespace, "namespace", "default", "preferred namespace for resources if they do not define one")
+	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
 	flagset.DurationVar(&params.Wait, "wait", 0, "time to wait for release to be ready")
 	flagset.DurationVar(&params.Poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
 

--- a/cmd/yoke/cmd_turbulence.go
+++ b/cmd/yoke/cmd_turbulence.go
@@ -50,7 +50,7 @@ func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulencePar
 	)
 	flagset.BoolVar(&params.Fix, "fix", false, "fix the drift. If present conflict-only will be true.")
 	flagset.BoolVar(&params.Color, "color", term.IsTerminal(int(os.Stdout.Fd())), "outputs diff with color")
-	flagset.StringVar(&params.Namespace, "namespace", "default", "target namespace of release")
+	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
 
 	flagset.Parse(args)
 

--- a/cmd/yoke/internal/testing/flights/name/main.go
+++ b/cmd/yoke/internal/testing/flights/name/main.go
@@ -11,6 +11,9 @@ import (
 )
 
 func main() {
+	var data map[string]string
+	_ = json.NewDecoder(os.Stdin).Decode(&data)
+
 	_ = json.NewEncoder(os.Stdout).Encode(corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -19,5 +22,6 @@ func main() {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: flight.Release(),
 		},
+		Data: data,
 	})
 }

--- a/cmd/yokecd/internal/plugin/run.go
+++ b/cmd/yokecd/internal/plugin/run.go
@@ -38,7 +38,7 @@ func Run(ctx context.Context, cfg Config) (err error) {
 			return nil, fmt.Errorf("failed to get in cluster config: %w", err)
 		}
 
-		client, err := k8s.NewClient(rest)
+		client, err := k8s.NewClient(rest, "")
 		if err != nil {
 			return nil, fmt.Errorf("failed to instantiate kubernetes clientset: %w", err)
 		}

--- a/cmd/yokecd/internal/svr/run.go
+++ b/cmd/yokecd/internal/svr/run.go
@@ -72,7 +72,7 @@ func Run(ctx context.Context, cfg Config) (err error) {
 		return fmt.Errorf("failed to get kubernetes config: %w", err)
 	}
 
-	client, err := k8s.NewClient(restCfg)
+	client, err := k8s.NewClient(restCfg, "")
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/pkg/yoke/yoke.go
+++ b/pkg/yoke/yoke.go
@@ -58,7 +58,7 @@ type DescentParams struct {
 func (commander Commander) Descent(ctx context.Context, params DescentParams) (err error) {
 	defer internal.DebugTimer(ctx, "descent")()
 
-	targetNS := cmp.Or(params.Namespace, "default")
+	targetNS := cmp.Or(params.Namespace, commander.k8s.DefaultNamespace)
 
 	release, err := commander.k8s.GetRelease(ctx, params.Release, targetNS)
 	if err != nil {
@@ -136,7 +136,7 @@ type MaydayParams struct {
 func (commander Commander) Mayday(ctx context.Context, params MaydayParams) error {
 	defer internal.DebugTimer(ctx, "mayday")()
 
-	targetNS := cmp.Or(params.Namespace, "default")
+	targetNS := cmp.Or(params.Namespace, commander.k8s.DefaultNamespace)
 
 	release, err := commander.k8s.GetRelease(ctx, params.Release, targetNS)
 	if err != nil {
@@ -144,7 +144,7 @@ func (commander Commander) Mayday(ctx context.Context, params MaydayParams) erro
 	}
 
 	if len(release.History) == 0 {
-		return internal.Warning("mayday noop: no history found for release: " + params.Release)
+		return internal.Warning(fmt.Sprintf("mayday noop: no history found for release %q in namespace %q", params.Release, targetNS))
 	}
 
 	stages, err := commander.k8s.GetRevisionResources(ctx, release.ActiveRevision())
@@ -180,7 +180,7 @@ type TurbulenceParams struct {
 func (commander Commander) Turbulence(ctx context.Context, params TurbulenceParams) error {
 	defer internal.DebugTimer(ctx, "turbulence")()
 
-	targetNS := cmp.Or(params.Namespace, "default")
+	targetNS := cmp.Or(params.Namespace, commander.k8s.DefaultNamespace)
 
 	if params.Silent {
 		ctx = internal.WithStderr(ctx, io.Discard)
@@ -308,6 +308,6 @@ type UnlockParams struct {
 func (commander Commander) UnlockRelease(ctx context.Context, params UnlockParams) error {
 	return commander.k8s.UnlockRelease(ctx, internal.Release{
 		Name:      params.Release,
-		Namespace: cmp.Or(params.Namespace, "default"),
+		Namespace: cmp.Or(params.Namespace, commander.k8s.DefaultNamespace),
 	})
 }

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -207,7 +207,7 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) (e
 		return ExportToFS(params.Out, params.Release, stages.Flatten())
 	}
 
-	targetNS := cmp.Or(params.Namespace, "default")
+	targetNS := cmp.Or(params.Namespace, commander.k8s.DefaultNamespace)
 	for _, stage := range stages {
 		internal.AddYokeMetadata(stage, params.Release, targetNS, params.ManagedBy)
 	}


### PR DESCRIPTION
This pull request modifies yoke to use the default namespace from current config context instead of always defaulting to "default".

This was brought up as a possible enhancement in the yoke discord.

TODO:
- [x] Add tests
- [x] Explore using overrides within the client instead of tracking namespace flag and plumbing it through to method calls.

---

Turns out using the override made the code much trickier as a client would need to be constructed and overridden in non-cli contexts such as the ATC and Argo plugin server. This was easy to do with a `client.WithNamespace` method however it was not obvious to ensure that all callsights were using the correct client.

An explicit client parameter works out better in practice.