### PR TITLE
yoke: propagate global flag settnings to subcommands as defaults

### DIFF
--- a/cmd/yoke/main.go
+++ b/cmd/yoke/main.go
@@ -150,7 +150,7 @@ type GlobalSettings struct {
 }
 
 func RegisterGlobalFlags(flagset *flag.FlagSet, settings *GlobalSettings) {
-	flagset.StringVar(settings.Kube.KubeConfig, "kubeconfig", cmp.Or(os.Getenv("KUBECONFIG"), home.Kubeconfig), "path to kube config")
-	flagset.StringVar(settings.Kube.Context, "kube-context", "", "kubernetes context to use")
-	flagset.BoolVar(settings.Debug, "debug", false, "debug output mode")
+	flagset.StringVar(settings.Kube.KubeConfig, "kubeconfig", cmp.Or(*settings.Kube.KubeConfig, os.Getenv("KUBECONFIG"), home.Kubeconfig), "path to kube config")
+	flagset.StringVar(settings.Kube.Context, "kube-context", *settings.Kube.Context, "kubernetes context to use")
+	flagset.BoolVar(settings.Debug, "debug", *settings.Debug, "debug output mode")
 }


### PR DESCRIPTION
The yoke CLI accepts certain flags at the root level:
- kubeconfig
- kube-context
- debug

And at subcommand level, but the root level ones were not being propagated to the actual command because the subcommands would overwrite the root set value with defaults.

This PR makes any value set at the root become the default for the subcommand for the duration of that command.
