### PR TITLE
ci: add github action to update embedded argocd chart

### DIFF
--- a/.github/workflows/argocd-chart-update.yaml
+++ b/.github/workflows/argocd-chart-update.yaml
@@ -1,0 +1,93 @@
+name: argocd chart update
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+on:
+  schedule:
+    - cron: "0 0 1,16 * *" # 00:00 on day 1 and 16 of each month
+  workflow_dispatch:
+
+jobs:
+  update-embedded-argocd:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            cmd
+            go.mod
+            go.sum
+            internal
+            pkg
+            Taskfile.yml
+
+      - name: Setup Taskfile
+        uses: go-task/setup-task@v1
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Check for new ArgoCD Chart version
+        id: diff
+        run: |
+          task update-yokecd-argo
+          if ! git diff --quiet; then
+            echo "new version detected, opening PR..."
+            echo "continue=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ArgoCD Chart is up to date, no action needed, exiting..."
+          fi
+
+      - name: Setup k3d
+        if: steps.diff.outputs.continue == 'true'
+        run: |
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+          k3d cluster create ci --wait
+
+      - name: Deploy and Validate ArgoCD
+        if: steps.diff.outputs.continue == 'true'
+        run: |
+          task build-cli
+          task yokecd-installer
+          ./yoke takeoff -create-namespace -namespace argocd -wait 10m argocd ./yokecd-installer.wasm
+
+      - name: Create PR
+        if: steps.diff.outputs.continue == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          BRANCH="yokecd-installer/argocd-chart-upgrade"
+          TITLE="yokecd-installer: bump ArgoCD Chart to latest"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add .
+          git commit -m "$TITLE"
+          git push origin "$BRANCH" --force
+
+          PR_STATE="$(gh pr view "$BRANCH" --json state -q .state 2>/dev/null || echo "NONE")"
+
+          if [[ "$PR_STATE" == "OPEN" ]]; then
+            echo "PR already open for $BRANCH, exiting..."
+          else
+            echo "No open PR found, creating PR..."
+            gh pr create \
+              --title "$TITLE" \
+              --body "Automated update of embedded ArgoCD Helm Chart." \
+              --base main \
+              --head "$BRANCH"
+          fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,7 @@
 #
 # go install github.com/go-task/task/v3/cmd/task@latest
 
-version: '3'
+version: "3"
 
 tasks:
   fmt:
@@ -31,7 +31,7 @@ tasks:
     cmds:
       - go install ./cmd/helm2go
       - rm -rf ./cmd/yokecd-installer/argocd
-      - helm2go -repo https://argoproj.github.io/argo-helm/argo-cd -outdir ./cmd/yokecd-installer/argocd -schema
+      - helm2go -repo https://argoproj.github.io/argo-helm/argo-cd -outdir ./cmd/yokecd-installer/argocd
       - task fmt
 
   wasm:


### PR DESCRIPTION
Relates to https://github.com/yokecd/yoke/issues/117

## What is the problem I am trying to solve:

Running Yoke in ArgoCD requires patching the ArgoCD Repository Server manifest with sidecar containers that implement the Yoke Plugin for ArgoCD.

This ArgoCD instance is deployed with the Helm Chart which needs to be manually updated.

## How is the problem being solved:

This PR adds a Github Action which runs weekly and does the following:

1. Identify if there's a version difference between the local helm chart and the latest published version
2. Replace the local helm chart with the latest published version if there's a difference, otherwise exit
3. Create a `k3d` Cluster and install the new helm chart with `yoke takeoff`
4. Validate that all ArgoCD Deployments are healthy, otherwise error
5. Force push changes to a `yokecd-installer/argocd-chart-upgrade` branch
6. See if the `yokecd-installer/argocd-chart-upgrade` branch has an associated PR, create one if not

## How I tested this change:

I ran the Github Action in my fork with `workflow_dispatch`

The first run creates PR https://github.com/seanturner026/yoke/pull/3

https://github.com/seanturner026/yoke/actions/runs/20548727925/job/59023301984

The second run again updated the chart (due to https://github.com/seanturner026/yoke/pull/3 being open at runtime) but then exited gracefully as it saw that there was already an existing PR.

https://github.com/seanturner026/yoke/actions/runs/20548931167/job/59023823423

The third run occurred after https://github.com/seanturner026/yoke/pull/3 was merged and exited gracefully because the local ArgoCD Helm Chart was up to date.

https://github.com/seanturner026/yoke/actions/runs/20548962017/job/59023895510