### PR TITLE
pkg/apis: implement runtime.Object for v1alhpa1 apis

### DIFF
--- a/cmd/atc-installer/main.go
+++ b/cmd/atc-installer/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 
 	"golang.org/x/mod/semver"
 	"golang.org/x/term"
@@ -32,7 +31,7 @@ func run() error {
 	flag.Parse()
 
 	if *schema {
-		return encodeAsYaml(os.Stdout, openapi.SchemaFrom(reflect.TypeFor[installer.Config]()))
+		return encodeAsYaml(os.Stdout, openapi.SchemaFor[installer.Config]())
 	}
 
 	if !*skipVersionCheck {

--- a/cmd/atc/internal/testing/flights/prune/main.go
+++ b/cmd/atc/internal/testing/flights/prune/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"os"
-	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -46,7 +45,7 @@ func main() {
 						Served:  true,
 						Storage: true,
 						Schema: &apiextensionsv1.CustomResourceValidation{
-							OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[struct{}]()),
+							OpenAPIV3Schema: openapi.SchemaFor[struct{}](),
 						},
 					},
 				},

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -180,7 +179,7 @@ func TestAirTrafficController(t *testing.T) {
 									Served:  true,
 									Storage: false, // THIS SHOULD TRIGGER AN ERROR. Invalid to have no storage version. This should be caught by admission validation.
 									Schema: &apiextv1.CustomResourceValidation{
-										OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+										OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 									},
 								},
 							},
@@ -221,7 +220,7 @@ func TestAirTrafficController(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+									OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 								},
 							},
 						},
@@ -375,7 +374,7 @@ func TestAirTrafficController(t *testing.T) {
 										Served:  true,
 										Storage: false,
 										Schema: &apiextv1.CustomResourceValidation{
-											OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+											OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 										},
 									},
 									{
@@ -383,7 +382,7 @@ func TestAirTrafficController(t *testing.T) {
 										Served:  true,
 										Storage: true,
 										Schema: &apiextv1.CustomResourceValidation{
-											OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv2.Backend]()),
+											OpenAPIV3Schema: openapi.SchemaFor[backendv2.Backend](),
 										},
 									},
 								},
@@ -639,7 +638,7 @@ func TestRestarts(t *testing.T) {
 										Served:  true,
 										Storage: true,
 										Schema: &apiextv1.CustomResourceValidation{
-											OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+											OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 										},
 									},
 								},
@@ -814,7 +813,7 @@ func TestCrossNamespace(t *testing.T) {
 							Served:  true,
 							Storage: true,
 							Schema: &apiextv1.CustomResourceValidation{
-								OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[EmptyCRD]()),
+								OpenAPIV3Schema: openapi.SchemaFor[EmptyCRD](),
 							},
 						},
 					},
@@ -949,7 +948,7 @@ func TestClusterScopeDynamicAirway(t *testing.T) {
 						Served:  true,
 						Storage: true,
 						Schema: &apiextv1.CustomResourceValidation{
-							OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[EmptyCRD]()),
+							OpenAPIV3Schema: openapi.SchemaFor[EmptyCRD](),
 						},
 					},
 				},
@@ -1089,7 +1088,7 @@ func TestHistoryCap(t *testing.T) {
 										Served:  true,
 										Storage: true,
 										Schema: &apiextv1.CustomResourceValidation{
-											OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+											OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 										},
 									},
 								},
@@ -1243,7 +1242,7 @@ func TestHistoryCap(t *testing.T) {
 										Served:  true,
 										Storage: true,
 										Schema: &apiextv1.CustomResourceValidation{
-											OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+											OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 										},
 									},
 								},
@@ -1330,7 +1329,7 @@ func TestFixDriftInterval(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+									OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 								},
 							},
 						},
@@ -1467,7 +1466,7 @@ func TestStatusReadiness(t *testing.T) {
 									Served:  true,
 									Storage: true,
 									Schema: &apiextv1.CustomResourceValidation{
-										OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[EmptyCRD]()),
+										OpenAPIV3Schema: openapi.SchemaFor[EmptyCRD](),
 									},
 								},
 							},
@@ -1659,7 +1658,7 @@ func TestResourceAccessMatchers(t *testing.T) {
 									Served:  true,
 									Storage: true,
 									Schema: &apiextv1.CustomResourceValidation{
-										OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[EmptyCRD]()),
+										OpenAPIV3Schema: openapi.SchemaFor[EmptyCRD](),
 									},
 								},
 							},
@@ -1787,7 +1786,7 @@ func TestAirwayModes(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+									OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 								},
 							},
 						},
@@ -2088,7 +2087,7 @@ func TestDynamicWithExternalResource(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[EmptyCRD]()),
+									OpenAPIV3Schema: openapi.SchemaFor[EmptyCRD](),
 								},
 							},
 						},
@@ -2255,7 +2254,7 @@ func TestExternalDynamicCreateEvent(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[CopyJob]()),
+									OpenAPIV3Schema: openapi.SchemaFor[CopyJob](),
 								},
 							},
 						},
@@ -2412,7 +2411,7 @@ func TestStatusUpdates(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[CR]()),
+									OpenAPIV3Schema: openapi.SchemaFor[CR](),
 								},
 							},
 						},
@@ -2656,7 +2655,7 @@ func TestDeploymentStatus(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[CR]()),
+									OpenAPIV3Schema: openapi.SchemaFor[CR](),
 								},
 							},
 						},
@@ -2776,7 +2775,7 @@ func TestPruning(t *testing.T) {
 									Served:  true,
 									Storage: true,
 									Schema: &apiextv1.CustomResourceValidation{
-										OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[struct{}]()),
+										OpenAPIV3Schema: openapi.SchemaFor[struct{}](),
 									},
 								},
 							},
@@ -3072,7 +3071,7 @@ func TestOverridePermissions(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+									OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 								},
 							},
 						},
@@ -3183,7 +3182,7 @@ func TestTimeout(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[EmptyCRD]()),
+									OpenAPIV3Schema: openapi.SchemaFor[EmptyCRD](),
 								},
 							},
 						},
@@ -3275,7 +3274,7 @@ func TestSubscriptionMode(t *testing.T) {
 								Served:  true,
 								Storage: true,
 								Schema: &apiextv1.CustomResourceValidation{
-									OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[EmptyCRD]()),
+									OpenAPIV3Schema: openapi.SchemaFor[EmptyCRD](),
 								},
 							},
 						},
@@ -3447,7 +3446,7 @@ func TestValidationCycle(t *testing.T) {
 							Served:  true,
 							Storage: true,
 							Schema: &apiextv1.CustomResourceValidation{
-								OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[backendv1.Backend]()),
+								OpenAPIV3Schema: openapi.SchemaFor[backendv1.Backend](),
 							},
 						},
 					},

--- a/cmd/atc/resources.go
+++ b/cmd/atc/resources.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -71,7 +70,7 @@ func ApplyResources(ctx context.Context, client *k8s.Client, cfg *Config) (teard
 						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
 					},
 					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[v1alpha1.Airway]()),
+						OpenAPIV3Schema: openapi.SchemaFor[v1alpha1.Airway](),
 					},
 					AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
 						{
@@ -143,7 +142,7 @@ func ApplyResources(ctx context.Context, client *k8s.Client, cfg *Config) (teard
 								Served:       true,
 								Storage:      true,
 								Subresources: &apiextensionsv1.CustomResourceSubresources{Status: &apiextensionsv1.CustomResourceSubresourceStatus{}},
-								Schema:       &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: openapi.SchemaFrom(reflect.TypeFor[v1alpha1.Flight]())},
+								Schema:       &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: openapi.SchemaFor[v1alpha1.Flight]()},
 								AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
 									{
 										Name:     "flight",

--- a/cmd/yokecd-installer/main.go
+++ b/cmd/yokecd-installer/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 
 	"go.yaml.in/yaml/v3"
 
@@ -55,7 +54,7 @@ func run() error {
 	flag.Parse()
 
 	if *schema {
-		return encodeAsYaml(os.Stdout, openapi.SchemaFrom(reflect.TypeFor[Values]()))
+		return encodeAsYaml(os.Stdout, openapi.SchemaFor[Values]())
 	}
 
 	values := Values{

--- a/internal/atc/reconciler_airway.go
+++ b/internal/atc/reconciler_airway.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -204,7 +203,7 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 		}
 		statusSchema, ok := version.Schema.OpenAPIV3Schema.Properties["status"]
 		if !ok {
-			version.Schema.OpenAPIV3Schema.Properties["status"] = *openapi.SchemaFrom(reflect.TypeFor[struct {
+			version.Schema.OpenAPIV3Schema.Properties["status"] = *(openapi.SchemaFor[struct {
 				Conditions flight.Conditions `json:"conditions,omitempty"`
 			}]())
 		} else {
@@ -215,9 +214,9 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 				statusSchema.Properties = map[string]apiextv1.JSONSchemaProps{}
 			}
 			if _, ok := statusSchema.Properties["conditions"]; !ok {
-				statusSchema.Properties["conditions"] = *openapi.SchemaFrom(reflect.TypeFor[flight.Conditions]())
+				statusSchema.Properties["conditions"] = *openapi.SchemaFor[flight.Conditions]()
 			}
-			if err := openapi.Satisfies(statusSchema.Properties["conditions"], *openapi.SchemaFrom(reflect.TypeFor[flight.Conditions]())); err != nil {
+			if err := openapi.Satisfies(statusSchema.Properties["conditions"], *openapi.SchemaFor[flight.Conditions]()); err != nil {
 				return ctrl.Result{}, fmt.Errorf("invalid airway: invalid status: conditions does not have expected schema: %v", err)
 			}
 

--- a/pkg/apis/deepcopy.go
+++ b/pkg/apis/deepcopy.go
@@ -1,0 +1,68 @@
+package apis
+
+import "reflect"
+
+// DeepCopy uses reflection to deep copy an object.
+// This is useful for add a naive implementation fo DeepCopyObject to satisfy the runtime.Object interface for your APIs
+// should you desire to use your APIs with controllerruntime or other k8s.io apis.
+//
+// The limitation of this implementation is that it does not support cyclical data, but since these types are expected to be serializable,
+// they shouldn't any way.
+//
+// Similarly funcs and channels are not supported as they also cannot be serialized safely.
+func DeepCopy[T any](in T) T {
+	return deepCopy(reflect.ValueOf(in)).Interface().(T)
+}
+
+func deepCopy(v reflect.Value) reflect.Value {
+	switch t := v.Type(); t.Kind() {
+	case reflect.Map:
+		if v.IsNil() {
+			return v
+		}
+		m := reflect.MakeMap(t)
+		iter := v.MapRange()
+		for iter.Next() {
+			m.SetMapIndex(deepCopy(iter.Key()), deepCopy(iter.Value()))
+		}
+		return m
+	case reflect.Slice:
+		if v.IsNil() {
+			return v
+		}
+		s := reflect.MakeSlice(t, v.Len(), v.Cap())
+		for i := range v.Len() {
+			s.Index(i).Set(deepCopy(v.Index(i)))
+		}
+		return s
+	case reflect.Array:
+		a := reflect.New(reflect.ArrayOf(v.Len(), t.Elem())).Elem()
+		for i := range v.Len() {
+			a.Index(i).Set(deepCopy(v.Index(i)))
+		}
+		return a
+	case reflect.Struct:
+		s := reflect.New(t).Elem()
+		for i := range v.NumField() {
+			if !t.Field(i).IsExported() {
+				continue
+			}
+			fv := v.Field(i)
+			s.Field(i).Set(deepCopy(fv))
+		}
+		return s
+	case reflect.Pointer:
+		if v.IsNil() {
+			return v
+		}
+		p := reflect.New(t.Elem())
+		p.Elem().Set(deepCopy(v.Elem()))
+		return p
+	case reflect.Chan:
+		panic("channels are not supported: not serializable")
+	case reflect.Func:
+		panic("funcs are not supported: not serializable")
+	default:
+		return v
+	}
+}

--- a/pkg/apis/deepcopy_test.go
+++ b/pkg/apis/deepcopy_test.go
@@ -1,0 +1,83 @@
+package apis_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/yokecd/yoke/pkg/apis"
+	"github.com/yokecd/yoke/pkg/apis/v1alpha1"
+)
+
+func TestDeepCopy(t *testing.T) {
+	t.Run("airway", func(t *testing.T) {
+		var a v1alpha1.Airway
+		b := apis.DeepCopy(a)
+		require.EqualValues(t, a, b)
+	})
+
+	t.Run("map", func(t *testing.T) {
+		original := map[string]*int{
+			"a": ptr.To(1),
+			"b": ptr.To(2),
+		}
+
+		copy := apis.DeepCopy(original)
+
+		require.EqualValues(t, len(original), len(copy))
+		for key := range original {
+			require.Equal(t, original[key], copy[key])
+			require.NotSame(t, original[key], copy[key])
+		}
+
+		original["c"] = ptr.To(3)
+		require.Len(t, original, 3)
+		require.Len(t, copy, 2)
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		original := []int{1, 2, 3}
+		copy := apis.DeepCopy(original)
+
+		require.Equal(t, len(original), len(copy))
+
+		for i := range original {
+			require.NotSame(t, &original[i], &copy[i])
+			require.Equal(t, original[i], copy[i])
+		}
+	})
+
+	t.Run("array", func(t *testing.T) {
+		original := [3]int{1, 2, 3}
+		copy := apis.DeepCopy(original)
+
+		require.Equal(t, len(original), len(copy))
+
+		for i := range original {
+			require.NotSame(t, &original[i], &copy[i])
+			require.Equal(t, original[i], copy[i])
+		}
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		original := struct {
+			A *int
+		}{
+			A: ptr.To(1),
+		}
+
+		copy := apis.DeepCopy(original)
+
+		require.Equal(t, original, copy)
+		require.NotSame(t, original.A, copy.A)
+	})
+
+	t.Run("pointers", func(t *testing.T) {
+		x := ptr.To(420)
+		y := apis.DeepCopy(x)
+		require.NotSame(t, x, y)
+		require.Equal(t, *x, *y)
+	})
+}

--- a/pkg/apis/v1alpha1/airway.go
+++ b/pkg/apis/v1alpha1/airway.go
@@ -7,9 +7,11 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 
+	"github.com/yokecd/yoke/pkg/apis"
 	"github.com/yokecd/yoke/pkg/flight"
 	"github.com/yokecd/yoke/pkg/openapi"
 )
@@ -245,4 +247,10 @@ func (airway Airway) CRGroupResource() schema.GroupResource {
 		Group:    airway.Spec.Template.Group,
 		Resource: airway.Spec.Template.Names.Plural,
 	}
+}
+
+var _ runtime.Object = (*Airway)(nil)
+
+func (airway *Airway) DeepCopyObject() runtime.Object {
+	return apis.DeepCopy(airway)
 }

--- a/pkg/apis/v1alpha1/airway.go
+++ b/pkg/apis/v1alpha1/airway.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	"reflect"
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -30,7 +29,7 @@ type Airway struct {
 
 func (Airway) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
 	type alt Airway
-	schema := openapi.SchemaFrom(reflect.TypeFor[alt]())
+	schema := openapi.SchemaFor[alt]()
 	schema.Description = strings.Join(
 		[]string{
 			"Airways are an high level CustomResourceDefintion object with metadata binding it to a Flight implementation.",
@@ -182,7 +181,7 @@ type AirwaySpec struct {
 
 func (AirwaySpec) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
 	type alt AirwaySpec
-	schema := openapi.SchemaFrom(reflect.TypeFor[alt]())
+	schema := openapi.SchemaFor[alt]()
 	schema.Description = "Specification of the Airway resource."
 	return schema
 }

--- a/pkg/apis/v1alpha1/flight.go
+++ b/pkg/apis/v1alpha1/flight.go
@@ -8,9 +8,11 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/yokecd/yoke/internal"
+	"github.com/yokecd/yoke/pkg/apis"
 	"github.com/yokecd/yoke/pkg/flight"
 	"github.com/yokecd/yoke/pkg/openapi"
 )
@@ -142,6 +144,12 @@ func (flight Flight) MarshalJSON() ([]byte, error) {
 	return json.Marshal(alt(flight))
 }
 
+var _ runtime.Object = (*Flight)(nil)
+
+func (flight *Flight) DeepCopyObject() runtime.Object {
+	return apis.DeepCopy(flight)
+}
+
 type ClusterFlight Flight
 
 func (ClusterFlight) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
@@ -166,4 +174,10 @@ func FlightInputStream(spec FlightSpec) io.Reader {
 		return internal.JSONReader(spec.InputObject)
 	}
 	return strings.NewReader("")
+}
+
+var _ runtime.Object = (*ClusterFlight)(nil)
+
+func (flight *ClusterFlight) DeepCopyObject() runtime.Object {
+	return apis.DeepCopy(flight)
 }

--- a/pkg/apis/v1alpha1/flight.go
+++ b/pkg/apis/v1alpha1/flight.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"encoding/json"
 	"io"
-	"reflect"
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -31,7 +30,7 @@ type Flight struct {
 
 func (Flight) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
 	type alt Flight
-	schema := openapi.SchemaFrom(reflect.TypeFor[alt]())
+	schema := openapi.SchemaFor[alt]()
 	schema.Description = strings.Join(
 		[]string{
 			"Flights allow you to create yoke releases in your cluster using the air traffic controller instead of a client-side implementation",
@@ -132,7 +131,7 @@ type FlightSpec struct {
 
 func (FlightSpec) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
 	type alt FlightSpec
-	schema := openapi.SchemaFrom(reflect.TypeFor[alt]())
+	schema := openapi.SchemaFor[alt]()
 	schema.Description = "Specification of the Flight and ClusterFlight custom resources."
 	return schema
 }
@@ -154,7 +153,7 @@ type ClusterFlight Flight
 
 func (ClusterFlight) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
 	type alt ClusterFlight
-	schema := openapi.SchemaFrom(reflect.TypeFor[alt]())
+	schema := openapi.SchemaFor[alt]()
 	schema.Description = "Cluser scoped version of the yoke.cd Flight resource. For more information see Flight."
 	return schema
 }

--- a/pkg/flight/status.go
+++ b/pkg/flight/status.go
@@ -1,8 +1,6 @@
 package flight
 
 import (
-	"reflect"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -20,7 +18,7 @@ type Status struct {
 type Conditions []metav1.Condition
 
 func (conditions Conditions) OpenAPISchema() *apiextensionsv1.JSONSchemaProps {
-	schema := openapi.SchemaFrom(reflect.TypeFor[[]metav1.Condition]())
+	schema := openapi.SchemaFor[[]metav1.Condition]()
 	schema.XListType = ptr.To("map")
 	schema.XListMapKeys = []string{"type"}
 	return schema


### PR DESCRIPTION
This pull request allows users to easily implement `runtime.Object`'s `DeepCopyObject` via reflection using `apis.DeepCopy`.

This allows types that are defined in code without kubernetes code-generation to satisfy this standard interface without much work.