### PR TITLE
yoke: breaking change: set release metadata as an annotation instead of labels

### DIFF
--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -1879,7 +1879,7 @@ func TestAirwayModes(t *testing.T) {
 			return nil
 		},
 		time.Second,
-		3*time.Second,
+		30*time.Second,
 		"failed to have admission webhook deny change",
 	)
 

--- a/cmd/yokecd/internal/plugin/run_e2e_test.go
+++ b/cmd/yokecd/internal/plugin/run_e2e_test.go
@@ -104,9 +104,11 @@ func TestPluginE2E(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name: "bar",
 					Labels: map[string]string{
-						"app.kubernetes.io/managed-by":             "yokecd",
-						"app.kubernetes.io/yoke-release":           "test",
-						"app.kubernetes.io/yoke-release-namespace": "foo",
+						internal.LabelManagedBy: "yokecd",
+					},
+					Annotations: map[string]string{
+						internal.AnnotationYokeRelease:   "test",
+						internal.AnnotationYokeNamespace: "foo",
 					},
 				},
 				Data: map[string]string{"potato": "farm"},
@@ -116,9 +118,11 @@ func TestPluginE2E(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
-						"app.kubernetes.io/managed-by":             "yokecd",
-						"app.kubernetes.io/yoke-release":           "test",
-						"app.kubernetes.io/yoke-release-namespace": "foo",
+						internal.LabelManagedBy: "yokecd",
+					},
+					Annotations: map[string]string{
+						internal.AnnotationYokeRelease:   "test",
+						internal.AnnotationYokeNamespace: "foo",
 					},
 				},
 				Data: map[string]string{"hello": "world"},

--- a/internal/atc/atc.go
+++ b/internal/atc/atc.go
@@ -13,9 +13,7 @@ const (
 	fieldManager           = "yoke.cd/atc"
 	cleanupFinalizer       = "yoke.cd/mayday.flight"
 	cleanupAirwayFinalizer = "yoke.cd/strip.airway"
-	LabelInstanceGroupKind = "instance.atc.yoke.cd/groupKind"
-	LabelInstanceName      = "instance.atc.yoke.cd/name"
-	LabelInstanceNamespace = "instance.atc.yoke.cd/namespace"
+	AnnotationInstanceRef  = "instance.atc.yoke.cd/instanceRef"
 )
 
 type InstanceState struct {

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -928,8 +928,8 @@ func (client Client) OrhpanResource(ctx context.Context, resource *unstructured.
 
 	patches := []PatchAction{
 		{Op: PatchOpRemove, Path: fmt.Sprintf("/metadata/labels/%s", strings.ReplaceAll(internal.LabelManagedBy, "/", "~1"))},
-		{Op: PatchOpRemove, Path: fmt.Sprintf("/metadata/labels/%s", strings.ReplaceAll(internal.LabelYokeRelease, "/", "~1"))},
-		{Op: PatchOpRemove, Path: fmt.Sprintf("/metadata/labels/%s", strings.ReplaceAll(internal.LabelYokeReleaseNS, "/", "~1"))},
+		{Op: PatchOpRemove, Path: fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(internal.AnnotationYokeRelease, "/", "~1"))},
+		{Op: PatchOpRemove, Path: fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(internal.AnnotationYokeNamespace, "/", "~1"))},
 	}
 
 	if len(resource.GetOwnerReferences()) > 0 {

--- a/internal/unstructed_test.go
+++ b/internal/unstructed_test.go
@@ -1,0 +1,57 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRef(t *testing.T) {
+	type Expected struct {
+		Name      string
+		Namespace string
+		GK        string
+	}
+	cases := []struct {
+		Name   string
+		Ref    string
+		Output Expected
+	}{
+		{
+			Name: "full",
+			Ref:  "ns/kind.group:name",
+			Output: Expected{
+				Name:      "name",
+				Namespace: "ns",
+				GK:        "kind.group",
+			},
+		},
+		{
+			Name: "gk only",
+			Ref:  "kind.group",
+			Output: Expected{
+				GK:        "kind.group",
+				Name:      "",
+				Namespace: "",
+			},
+		},
+		{
+			Name: "namespace only",
+			Ref:  "default/",
+			Output: Expected{
+				Name:      "",
+				Namespace: "default",
+				GK:        "",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ns, gk, name := ParseRef(tc.Ref)
+			require.Equal(t, tc.Output.Name, name)
+			require.Equal(t, tc.Output.Namespace, ns)
+			require.Equal(t, tc.Output.GK, gk)
+		})
+	}
+}

--- a/internal/unstructured.go
+++ b/internal/unstructured.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -149,13 +150,19 @@ func IsCRD(resource *unstructured.Unstructured) bool {
 	}
 }
 
-func GetAnnotation(resource unstructured.Unstructured, key string) string {
-	if annotations := resource.GetAnnotations(); annotations != nil {
-		return annotations[key]
-	}
-	return ""
-}
-
 func ResourceRef(resource *unstructured.Unstructured) string {
 	return fmt.Sprintf("%s/%s:%s", resource.GetNamespace(), resource.GroupVersionKind().GroupKind().String(), resource.GetName())
+}
+
+func ParseRef(ref string) (ns, gk, name string) {
+	if ref == "" {
+		return
+	}
+	ns, rest, ok := strings.Cut(ref, "/")
+	if !ok {
+		rest = ns
+		ns = ""
+	}
+	gk, name, _ = strings.Cut(rest, ":")
+	return
 }

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -140,6 +140,10 @@ type TakeoffParams struct {
 	// Example: used by the ATC to add Instance metadata
 	ExtraLabels map[string]string
 
+	// ExtraAnnotations adds extra annotations to resources deployed by yoke.
+	// Example: used by the ATC to add Instance metadata
+	ExtraAnnotations map[string]string
+
 	// ManagedBy is the value used in the yoke managed-by label. If left empty will default to `yoke`.
 	ManagedBy string
 
@@ -241,14 +245,24 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) (e
 		}
 	}
 
-	if len(params.ExtraLabels) > 0 {
+	if len(params.ExtraLabels)+len(params.ExtraAnnotations) > 0 {
 		for _, resource := range stages.Flatten() {
-			labels := resource.GetLabels()
-			if labels == nil {
-				labels = map[string]string{}
+			if len(params.ExtraLabels) > 0 {
+				labels := resource.GetLabels()
+				if labels == nil {
+					labels = map[string]string{}
+				}
+				maps.Copy(labels, params.ExtraLabels)
+				resource.SetLabels(labels)
 			}
-			maps.Copy(labels, params.ExtraLabels)
-			resource.SetLabels(labels)
+			if len(params.ExtraAnnotations) > 0 {
+				annotations := resource.GetAnnotations()
+				if annotations == nil {
+					annotations = map[string]string{}
+				}
+				maps.Copy(annotations, params.ExtraAnnotations)
+				resource.SetAnnotations(annotations)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR aims to solve #238.

The issue is that yoke adds metadata to the resources it creates:
- core cli: adds release and namespace properties to tie it to its release history as well as establish ownership rules.
- atc: identify the parent instance during admission, to implement airways modes and to requeue reconciliation when needed.

However, this metadata was being stored as labels which have restrictions on their character set and length needing to be subdomain compliant.

This would cause issues for releases created by the ATC as the release name comprises of identifying parts of the parent instance: gk+namespace+name. For users with APIs with long groupKinds and namespaces, this left very few characters left for the name and would cause errors.

This PR saves this metadata as an annotation circumventing these issues.

> **IMPORTANT**
> This PR is marked as a breaking change in order to get a minor version bump as this change is important.
> However, before merging we will need to make sure this is in fact backwards compatible, and doesn't break current users on older versions when upgrading.