### PR TITLE
yoke: add digest pinning using release history

### DIFF
--- a/internal/pin.go
+++ b/internal/pin.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"net/url"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+func IsPinnableReference(ref string) bool {
+	uri, err := url.Parse(ref)
+	if err != nil {
+		return false
+	}
+	switch uri.Scheme {
+	// local wasm files are for development.
+	// We can assume the user is deliberately developing modules or at the very least
+	// that they are responsible for managing and deploying from modules on their own system.
+	case "file":
+		return false
+
+	// If the tag of an oci module is semver we pin that version.
+	// Otherwise it could be a semantically meaningful tag such as "latest" or "nightly",
+	// which is inherently expected to change over time.
+	case "oci":
+		_, tag, _ := strings.Cut(uri.Path, ":")
+		if tag == "" {
+			return false // same as latest
+		}
+		if !strings.HasPrefix(tag, "v") {
+			tag = "v" + tag
+		}
+		return semver.IsValid(tag)
+
+	// For modules hosted over http, there is no standard. Hence we can't use any existing convention.
+	// We may in the future decide to define a convention such as semver in the last path segment.
+	// But for now we treat modules over http as "dangerous/volatile" and we pin them.
+	case "http", "https":
+		return true
+
+	// No other known cases for now. We could panic, but let's just pin as a safe default.
+	default:
+		return true
+	}
+}

--- a/internal/pin_test.go
+++ b/internal/pin_test.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPinnableReference(t *testing.T) {
+	for _, ref := range []string{
+		"oci://ghcr.io/repo/mod:v1.2.3",
+		"oci://ghcr.io/repo/mod:1.2.3",
+		"oci://ghcr.io/repo/mod:v1",
+		"oci://ghcr.io/repo/mod:1",
+		"oci://ghcr.io/repo/mod:v1.2.3-prerelease",
+		"oci://ghcr.io/repo/mod:1.2.3-prerelease",
+		"oci://ghcr.io/repo/mod:v1.2.3-prerelease+build",
+		"oci://ghcr.io/repo/mod:1.2.3-prerelease+build",
+		"http://domain.io/module.wasm.gz",
+	} {
+		require.Truef(t, IsPinnableReference(ref), "expected %s to be pinnable but is not", ref)
+	}
+
+	for _, ref := range []string{
+		"oci://ghcr.io/repo/mod",
+		"oci://ghcr.io/repo/mod:latest",
+		"oci://ghcr.io/repo/mod:stable",
+		"oci://ghcr.io/repo/mod:experimental",
+		"file://./main.wasm",
+	} {
+		require.Falsef(t, IsPinnableReference(ref), "expected %s to not be pinnable but is", ref)
+	}
+}


### PR DESCRIPTION
This pull request introduces digest pinning.

All releases track the checksum of the wasm module used to produce the desired release state.

Now if a pinnable wasm reference's checksum changes (the reference is in the release history), then it will be rejected.
