### PR TITLE
atc: decouple crd deletion from airway reconciliation loop

### DIFF
--- a/cmd/atc/handler.go
+++ b/cmd/atc/handler.go
@@ -130,7 +130,7 @@ func Handler(params HandlerParams) http.Handler {
 				continue
 			}
 
-			unstructured.SetNestedField(raw, originalStatus, "status")
+			_ = unstructured.SetNestedField(raw, originalStatus, "status")
 
 			data, err := json.Marshal(raw)
 			if err != nil {

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -96,23 +96,41 @@ func run() (err error) {
 	eventDispatcher := new(atc.EventDispatcher)
 	flightStates := &xsync.Map[string, atc.InstanceState]{}
 
-	var wg sync.WaitGroup
-	wg.Add(3)
+	controller := ctrl.NewController(ctx, ctrl.Params{
+		Client:      client,
+		Logger:      logger.With("component", "controller"),
+		Concurrency: max(cfg.Concurrency, 1),
+	})
+	if err := controller.Register(
+		ctrl.Entry{
+			GroupKind: schema.GroupKind{Group: "yoke.cd", Kind: v1alpha1.KindAirway},
+			Forwarders: []schema.GroupKind{{
+				Group: "apiextensions.k8s.io",
+				Kind:  "CustomResourceDefinition",
+			}},
+			Funcs: atc.GetAirwayReconciler(cfg.Service, moduleCache, eventDispatcher, flightStates),
+		},
+		ctrl.Entry{
+			GroupKind: schema.GroupKind{Group: "yoke.cd", Kind: v1alpha1.KindFlight},
+			Funcs:     atc.FlightReconciler(moduleCache),
+		},
+		ctrl.Entry{
+			GroupKind: schema.GroupKind{Group: "yoke.cd", Kind: v1alpha1.KindClusterFlight},
+			Funcs:     atc.ClusterFlightReconsiler(moduleCache),
+		},
+	); err != nil {
+		return fmt.Errorf("failed to register group kind handlers: %w", err)
+	}
 
+	var wg sync.WaitGroup
 	defer wg.Wait()
 
 	e := make(chan error, 3)
 
-	go func() {
-		wg.Wait()
-		close(e)
-	}()
-
 	ctx, cancel = context.WithCancel(ctx)
 	defer cancel()
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		if cfg.DockerConfigSecretName == "" {
 			return
 		}
@@ -125,32 +143,16 @@ func run() (err error) {
 		}); err != nil {
 			e <- fmt.Errorf("error watching docker config secret: %w", err)
 		}
-	}()
-
-	controller := ctrl.NewController(ctx, ctrl.Params{
-		Client:      client,
-		Logger:      logger.With("component", "controller"),
-		Concurrency: max(cfg.Concurrency, 1),
 	})
-	if err := controller.RegisterGKs(map[schema.GroupKind]ctrl.Funcs{
-		{Group: "yoke.cd", Kind: v1alpha1.KindAirway}:        atc.GetAirwayReconciler(cfg.Service, moduleCache, eventDispatcher, flightStates),
-		{Group: "yoke.cd", Kind: v1alpha1.KindFlight}:        atc.FlightReconciler(moduleCache),
-		{Group: "yoke.cd", Kind: v1alpha1.KindClusterFlight}: atc.ClusterFlightReconsiler(moduleCache),
-	}); err != nil {
-		return fmt.Errorf("failed to register group kind handlers: %w", err)
-	}
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		logger.Info("Controller Starting", "concurrency", controller.Concurrency)
 		if err := controller.Run(); err != nil {
 			e <- fmt.Errorf("controller exited run with error: %w", err)
 		}
-	}()
+	})
 
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		filter := func() xhttp.LogFilterFunc {
 			if cfg.Verbose {
 				return nil
@@ -199,6 +201,11 @@ func run() (err error) {
 		}
 
 		logger.Info("ATC/Server shutdown completed successfully")
+	})
+
+	go func() {
+		wg.Wait()
+		close(e)
 	}()
 
 	return <-e

--- a/internal/atc/reconciler_airway.go
+++ b/internal/atc/reconciler_airway.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 
 	"github.com/yokecd/yoke/internal"
@@ -90,7 +91,7 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 	if !airway.DeletionTimestamp.IsZero() {
 		airwayStatus(metav1.ConditionFalse, "Terminating", "cleaning up resources")
 
-		if idx := slices.Index(airway.Finalizers, cleanupAirwayFinalizer); idx > -1 {
+		if slices.Contains(airway.Finalizers, cleanupAirwayFinalizer) {
 			if err := webhookIntf.Delete(ctx, airway.CRGroupResource().String(), metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				return ctrl.Result{}, fmt.Errorf("failed to remove admission validation webhook: %w", err)
 			}
@@ -105,32 +106,40 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 				PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
 			}
 
-			if err := crdIntf.Delete(ctx, airway.Name, foregroundDelete); err != nil && !kerrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("failed to remove custom resource definiton associated to airway: %v", err)
+			crd, err := crdIntf.Get(ctx, airway.Name, metav1.GetOptions{})
+			if err != nil && !kerrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to get custom resource definition for airway: %w", err)
 			}
 
-			for attempt := range 10 {
-				if _, err := crdIntf.Get(ctx, airway.Name, metav1.GetOptions{}); err != nil {
-					if kerrors.IsNotFound(err) {
-						break
+			if kerrors.IsNotFound(err) {
+				if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					airway, err := airwayIntf.Get(ctx, airway.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
 					}
-					return ctrl.Result{}, fmt.Errorf("failed to get CRD associated to airway: %v", err)
+					idx := slices.Index(airway.Finalizers, cleanupAirwayFinalizer)
+					if idx < 0 {
+						return nil
+					}
+					airway.SetFinalizers(slices.Delete(airway.Finalizers, idx, idx+1))
+					if _, err := airwayIntf.Update(ctx, airway, metav1.UpdateOptions{FieldManager: fieldManager}); err != nil {
+						return err
+					}
+					return nil
+				}); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to remove airway cleanup finalizer: %v", err)
 				}
-				if attempt == 9 {
-					return ctrl.Result{}, fmt.Errorf("termination is hung: crd is not being deleted: manual intervention may be needed")
+				if cleanup := atc.cleanups[airway.Name]; cleanup != nil {
+					cleanup()
 				}
-				time.Sleep(time.Second)
+				return ctrl.Result{}, nil
 			}
 
-			if cleanup := atc.cleanups[airway.Name]; cleanup != nil {
-				cleanup()
-			}
-
-			finalizers := slices.Delete(airway.Finalizers, idx, idx+1)
-			airway.SetFinalizers(finalizers)
-
-			if _, err := airwayIntf.Update(ctx, airway, metav1.UpdateOptions{FieldManager: fieldManager}); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to remove cleanup finalizer to airway: %v", err)
+			if crd.GetDeletionTimestamp().IsZero() {
+				if err := crdIntf.Delete(ctx, airway.Name, foregroundDelete); err != nil && !kerrors.IsNotFound(err) {
+					return ctrl.Result{}, fmt.Errorf("failed to remove custom resource definiton associated to airway: %v", err)
+				}
+				airwayStatus(metav1.ConditionFalse, "Terminating", "cleaning up resources")
 			}
 			return ctrl.Result{}, nil
 		}
@@ -364,7 +373,10 @@ func (atc atc) Reconcile(ctx context.Context, event ctrl.Event) (result ctrl.Res
 		States:  atc.flightStates,
 	}
 
-	if err := ctrl.Inst(ctx).RegisterGK(flightGK, atc.InstanceReconciler(reconcilerParams)); err != nil {
+	if err := ctrl.Inst(ctx).Register(ctrl.Entry{
+		GroupKind: flightGK,
+		Funcs:     atc.InstanceReconciler(reconcilerParams),
+	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to register flight controller for gk: %w", err)
 	}
 

--- a/internal/k8s/ctrl/controller.go
+++ b/internal/k8s/ctrl/controller.go
@@ -88,20 +88,26 @@ func NewController(ctx context.Context, params Params) *Instance {
 	}
 }
 
-func (instance *Instance) RegisterGKs(gks map[schema.GroupKind]Funcs) error {
+type Entry struct {
+	GroupKind  schema.GroupKind
+	Forwarders []schema.GroupKind
+	Funcs      Funcs
+}
+
+func (instance *Instance) Register(entries ...Entry) error {
 	var errs []error
-	for gk, funcs := range gks {
-		if err := instance.RegisterGK(gk, funcs); err != nil {
-			errs = append(errs, fmt.Errorf("%s: %w", gk, err))
+	for _, entry := range entries {
+		if err := instance.register(entry); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", entry.GroupKind, err))
 		}
 	}
 	return xerr.JoinOrdered(errs...)
 }
 
-func (instance *Instance) RegisterGK(gk schema.GroupKind, funcs Funcs) error {
+func (instance *Instance) register(entry Entry) error {
 	instance.Client.Mapper.Reset()
 
-	mapping, err := instance.Client.Mapper.RESTMapping(gk)
+	mapping, err := instance.Client.Mapper.RESTMapping(entry.GroupKind)
 	if err != nil {
 		return fmt.Errorf("failed to get rest mapping: %w", err)
 	}
@@ -110,13 +116,19 @@ func (instance *Instance) RegisterGK(gk schema.GroupKind, funcs Funcs) error {
 
 	informer := factory.ForResource(mapping.Resource).Informer()
 
-	informerHandler := func(obj any) {
-		resource := obj.(*unstructured.Unstructured)
-		instance.events.Enqueue(Event{
-			Name:      resource.GetName(),
-			Namespace: resource.GetNamespace(),
-			GroupKind: gk,
-		})
+	var resourceMap xsync.Set[Event]
+
+	informerHandler := func(op func(Event)) func(obj any) {
+		return func(obj any) {
+			resource := obj.(*unstructured.Unstructured)
+			event := Event{
+				Name:      resource.GetName(),
+				Namespace: resource.GetNamespace(),
+				GroupKind: entry.GroupKind,
+			}
+			instance.events.Enqueue(event)
+			op(event)
+		}
 	}
 
 	informerUpdateHandler := func(oldObj any, newObj any) {
@@ -125,16 +137,18 @@ func (instance *Instance) RegisterGK(gk schema.GroupKind, funcs Funcs) error {
 		if internal.ResourcesAreEqual(prev, next) {
 			return
 		}
-		instance.events.Enqueue(Event{
+		event := Event{
 			Name:      next.GetName(),
 			Namespace: next.GetNamespace(),
-			GroupKind: gk,
-		})
+			GroupKind: entry.GroupKind,
+		}
+		instance.events.Enqueue(event)
+		resourceMap.Add(event)
 	}
 
 	eventHandlers := kcache.ResourceEventHandlerFuncs{
-		AddFunc:    informerHandler,
-		DeleteFunc: informerHandler,
+		AddFunc:    informerHandler(resourceMap.Add),
+		DeleteFunc: informerHandler(resourceMap.Del),
 		UpdateFunc: informerUpdateHandler,
 	}
 
@@ -142,19 +156,46 @@ func (instance *Instance) RegisterGK(gk schema.GroupKind, funcs Funcs) error {
 		return fmt.Errorf("failed to add event handlers: %w", err)
 	}
 
+	for _, forward := range entry.Forwarders {
+		mapping, err := instance.Client.Mapper.RESTMapping(forward)
+		if err != nil {
+			return fmt.Errorf("failed to get rest mapping: %w", err)
+		}
+
+		requeue := func(obj any) {
+			resource := obj.(*unstructured.Unstructured)
+			evt := Event{
+				Name:      resource.GetName(),
+				Namespace: resource.GetNamespace(),
+				GroupKind: entry.GroupKind,
+			}
+			if resourceMap.Has(evt) {
+				instance.events.Enqueue(evt)
+			}
+		}
+
+		if _, err := factory.ForResource(mapping.Resource).Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
+			AddFunc:    requeue,
+			UpdateFunc: func(_ any, obj any) { requeue(obj) },
+			DeleteFunc: requeue,
+		}); err != nil {
+			return fmt.Errorf("failed to add event handlers for forwarder: %s: %w", forward, err)
+		}
+	}
+
 	done := make(chan struct{})
 
 	factory.Start(done)
 
 	instance.gks.Store(
-		gk,
+		entry.GroupKind,
 		gkstate{
-			handler: funcs.Handler,
+			handler: entry.Funcs.Handler,
 			shutdown: xsync.OnceFunc(func() {
 				close(done)
 				factory.Shutdown()
-				instance.gks.Delete(gk)
-				funcs.Teardown()
+				instance.gks.Delete(entry.GroupKind)
+				entry.Funcs.Teardown()
 			}),
 		},
 	)


### PR DESCRIPTION
Airway deletion causes a cascade of deletions.

The backing CRD for your airway gets deleted, and the CRs associated to that CRD get deleted, and the releases deployed by those CRs get deleted.

Its essentially a LIFO queue of deletions.

Previously the reconciliation loop for Airways would attempt to wait for the CRD to be deleted before it could remove its finalizer and finally allow itself to be deleted.

However you do not want to wait in a reconciliation loop as that blocks an entire goroutine used for processing events.
This PR forwards CRD events to the Airway reconciliation loop, allowing the reconciliation loop to exit quickly, and resume once the CRD is finally deleted.
