### PR TITLE
CLI Completion 

### DIFF
--- a/cmd/yoke/cmd_atc.go
+++ b/cmd/yoke/cmd_atc.go
@@ -30,22 +30,22 @@ var CmdATC = &YokeCommand{
 	FlagSet: flag.NewFlagSet("atc", flag.ExitOnError),
 }
 
+var atcParams = ATCParams{}
+
 func init() {
+	flagset := CmdATC.FlagSet
+	flagset.StringVar(&atcParams.Debug, "debug-file", "", "debug file")
 	CmdRoot.AddCommand(CmdATC)
 }
 
 func GetAtcParams(settings GlobalSettings, args []string) ATCParams {
 	flagset := CmdATC.FlagSet
-
-	params := ATCParams{GlobalSettings: settings}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
-
-	flagset.StringVar(&params.Debug, "debug-file", "", "debug file")
+	atcParams.GlobalSettings = settings
+	RegisterGlobalFlags(flagset, &atcParams.GlobalSettings)
 
 	flagset.Parse(args)
 
-	return params
+	return atcParams
 }
 
 func ATC(ctx context.Context, params ATCParams) error {

--- a/cmd/yoke/cmd_atc.go
+++ b/cmd/yoke/cmd_atc.go
@@ -25,19 +25,18 @@ type ATCParams struct {
 	Debug string
 }
 
-func GetAtcParams(settings GlobalSettings, args []string) ATCParams {
+var CmdATC = NewCommand("atc", []string{}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
 	flagset := flag.NewFlagSet("atc", flag.ExitOnError)
-
-	params := ATCParams{GlobalSettings: settings}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
-
+	params := ATCParams{}
 	flagset.StringVar(&params.Debug, "debug-file", "", "debug file")
-
-	flagset.Parse(args)
-
-	return params
-}
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
+		params.GlobalSettings = settings
+		RegisterGlobalFlags(flagset, &params.GlobalSettings)
+		flagset.Parse(args)
+		ATC(ctx, params)
+		return nil
+	}
+})
 
 func ATC(ctx context.Context, params ATCParams) error {
 	client, err := k8s.NewClientFromConfigFlags(params.Kube)

--- a/cmd/yoke/cmd_atc.go
+++ b/cmd/yoke/cmd_atc.go
@@ -25,8 +25,17 @@ type ATCParams struct {
 	Debug string
 }
 
+var CmdATC = &YokeCommand{
+	Name:     "atc",
+	FlagsSet: flag.NewFlagSet("atc", flag.ExitOnError),
+}
+
+func init() {
+	CmdRoot.AddCommand(CmdATC)
+}
+
 func GetAtcParams(settings GlobalSettings, args []string) ATCParams {
-	flagset := flag.NewFlagSet("atc", flag.ExitOnError)
+	flagset := CmdATC.FlagsSet
 
 	params := ATCParams{GlobalSettings: settings}
 

--- a/cmd/yoke/cmd_atc.go
+++ b/cmd/yoke/cmd_atc.go
@@ -26,8 +26,8 @@ type ATCParams struct {
 }
 
 var CmdATC = &YokeCommand{
-	Name:     "atc",
-	FlagsSet: flag.NewFlagSet("atc", flag.ExitOnError),
+	Name:    "atc",
+	FlagSet: flag.NewFlagSet("atc", flag.ExitOnError),
 }
 
 func init() {
@@ -35,7 +35,7 @@ func init() {
 }
 
 func GetAtcParams(settings GlobalSettings, args []string) ATCParams {
-	flagset := CmdATC.FlagsSet
+	flagset := CmdATC.FlagSet
 
 	params := ATCParams{GlobalSettings: settings}
 

--- a/cmd/yoke/cmd_blackbox.go
+++ b/cmd/yoke/cmd_blackbox.go
@@ -33,9 +33,9 @@ type BlackboxParams struct {
 var blackboxHelp string
 
 var CmdBlackbox = &YokeCommand{
-	Name:     "blackbox",
-	Aliases:  []string{"inspect"},
-	FlagsSet: flag.NewFlagSet("blackbox", flag.ExitOnError),
+	Name:    "blackbox",
+	Aliases: []string{"inspect"},
+	FlagSet: flag.NewFlagSet("blackbox", flag.ExitOnError),
 }
 
 func init() {
@@ -44,7 +44,7 @@ func init() {
 }
 
 func GetBlackBoxParams(settings GlobalSettings, args []string) (*BlackboxParams, error) {
-	flagset := CmdBlackbox.FlagsSet
+	flagset := CmdBlackbox.FlagSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), blackboxHelp)

--- a/cmd/yoke/cmd_blackbox.go
+++ b/cmd/yoke/cmd_blackbox.go
@@ -37,35 +37,38 @@ var CmdBlackbox = &YokeCommand{
 	Aliases: []string{"inspect"},
 	FlagSet: flag.NewFlagSet("blackbox", flag.ExitOnError),
 }
+var (
+	blackboxParams BlackboxParams
+)
 
 func init() {
 	blackboxHelp = strings.TrimSpace(internal.Colorize(blackboxHelp))
+	flagset := CmdBlackbox.FlagSet
+	flagset.IntVar(&blackboxParams.Context, "context", 4, "number of lines of context in diff (ignored if not comparing revisions)")
+	flagset.StringVar(&blackboxParams.Namespace, "namespace", "", "namespace of release to inspect")
+	flagset.Usage = func() {
+		fmt.Fprintln(flagset.Output(), blackboxHelp)
+		flagset.PrintDefaults()
+	}
 	CmdRoot.AddCommand(CmdBlackbox)
 }
 
 func GetBlackBoxParams(settings GlobalSettings, args []string) (*BlackboxParams, error) {
 	flagset := CmdBlackbox.FlagSet
 
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), blackboxHelp)
-		flagset.PrintDefaults()
-	}
+	blackboxParams.GlobalSettings = settings
+	RegisterGlobalFlags(flagset, &blackboxParams.GlobalSettings)
 
-	params := BlackboxParams{GlobalSettings: settings}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
-	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff (ignored if not comparing revisions)")
-	flagset.StringVar(&params.Namespace, "namespace", "", "namespace of release to inspect")
 	flagset.Parse(args)
 
-	params.Release = flagset.Arg(0)
+	blackboxParams.Release = flagset.Arg(0)
 
 	if revision := flagset.Arg(1); revision != "" {
 		revisionID, err := strconv.Atoi(flagset.Arg(1))
 		if err != nil {
 			return nil, fmt.Errorf("revision must be an integer ID: %w", err)
 		}
-		params.RevisionID = revisionID
+		blackboxParams.RevisionID = revisionID
 	}
 
 	if revision := flagset.Arg(2); revision != "" {
@@ -73,10 +76,10 @@ func GetBlackBoxParams(settings GlobalSettings, args []string) (*BlackboxParams,
 		if err != nil {
 			return nil, fmt.Errorf("revision to diff must be an integer ID: %w", err)
 		}
-		params.DiffRevisionID = revisionID
+		blackboxParams.DiffRevisionID = revisionID
 	}
 
-	return &params, nil
+	return &blackboxParams, nil
 }
 
 func Blackbox(ctx context.Context, params BlackboxParams) error {

--- a/cmd/yoke/cmd_blackbox.go
+++ b/cmd/yoke/cmd_blackbox.go
@@ -32,45 +32,39 @@ type BlackboxParams struct {
 //go:embed cmd_blackbox_help.txt
 var blackboxHelp string
 
-func init() {
-	blackboxHelp = strings.TrimSpace(internal.Colorize(blackboxHelp))
-}
-
-func GetBlackBoxParams(settings GlobalSettings, args []string) (*BlackboxParams, error) {
+var CmdBlackbox = NewCommand("blackbox", []string{"inspect"}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
+	params := BlackboxParams{}
 	flagset := flag.NewFlagSet("blackbox", flag.ExitOnError)
 
+	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff (ignored if not comparing revisions)")
+	flagset.StringVar(&params.Namespace, "namespace", "", "namespace of release to inspect")
 	flagset.Usage = func() {
+		blackboxHelp = strings.TrimSpace(internal.Colorize(blackboxHelp))
 		fmt.Fprintln(flagset.Output(), blackboxHelp)
 		flagset.PrintDefaults()
 	}
-
-	params := BlackboxParams{GlobalSettings: settings}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
-	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff (ignored if not comparing revisions)")
-	flagset.StringVar(&params.Namespace, "namespace", "", "namespace of release to inspect")
-	flagset.Parse(args)
-
-	params.Release = flagset.Arg(0)
-
-	if revision := flagset.Arg(1); revision != "" {
-		revisionID, err := strconv.Atoi(flagset.Arg(1))
-		if err != nil {
-			return nil, fmt.Errorf("revision must be an integer ID: %w", err)
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
+		params.GlobalSettings = settings
+		RegisterGlobalFlags(flagset, &params.GlobalSettings)
+		flagset.Parse(args)
+		params.Release = flagset.Arg(0)
+		if revision := flagset.Arg(1); revision != "" {
+			revisionID, err := strconv.Atoi(flagset.Arg(1))
+			if err != nil {
+				return fmt.Errorf("revision must be an integer ID: %w", err)
+			}
+			params.RevisionID = revisionID
 		}
-		params.RevisionID = revisionID
-	}
-
-	if revision := flagset.Arg(2); revision != "" {
-		revisionID, err := strconv.Atoi(flagset.Arg(2))
-		if err != nil {
-			return nil, fmt.Errorf("revision to diff must be an integer ID: %w", err)
+		if revision := flagset.Arg(2); revision != "" {
+			revisionID, err := strconv.Atoi(flagset.Arg(2))
+			if err != nil {
+				return fmt.Errorf("revision to diff must be an integer ID: %w", err)
+			}
+			params.DiffRevisionID = revisionID
 		}
-		params.DiffRevisionID = revisionID
+		return Blackbox(ctx, params)
 	}
-
-	return &params, nil
-}
+})
 
 func Blackbox(ctx context.Context, params BlackboxParams) error {
 	client, err := k8s.NewClientFromConfigFlags(params.Kube)

--- a/cmd/yoke/cmd_blackbox.go
+++ b/cmd/yoke/cmd_blackbox.go
@@ -32,12 +32,19 @@ type BlackboxParams struct {
 //go:embed cmd_blackbox_help.txt
 var blackboxHelp string
 
+var CmdBlackbox = &YokeCommand{
+	Name:     "blackbox",
+	Aliases:  []string{"inspect"},
+	FlagsSet: flag.NewFlagSet("blackbox", flag.ExitOnError),
+}
+
 func init() {
 	blackboxHelp = strings.TrimSpace(internal.Colorize(blackboxHelp))
+	CmdRoot.AddCommand(CmdBlackbox)
 }
 
 func GetBlackBoxParams(settings GlobalSettings, args []string) (*BlackboxParams, error) {
-	flagset := flag.NewFlagSet("blackbox", flag.ExitOnError)
+	flagset := CmdBlackbox.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), blackboxHelp)

--- a/cmd/yoke/cmd_descent.go
+++ b/cmd/yoke/cmd_descent.go
@@ -16,7 +16,7 @@ import (
 //go:embed cmd_descent_help.txt
 var descentHelp string
 
-var CmdDescend = &YokeCommand{
+var CmdDescent = &YokeCommand{
 	Name:     "descent",
 	Aliases:  []string{"down", "restore"},
 	FlagsSet: flag.NewFlagSet("descent", flag.ExitOnError),
@@ -24,7 +24,7 @@ var CmdDescend = &YokeCommand{
 
 func init() {
 	descentHelp = strings.TrimSpace(internal.Colorize(descentHelp))
-	CmdRoot.AddCommand(CmdDescend)
+	CmdRoot.AddCommand(CmdDescent)
 }
 
 type DescentParams struct {
@@ -33,7 +33,7 @@ type DescentParams struct {
 }
 
 func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, error) {
-	flagset := CmdDescend.FlagsSet
+	flagset := CmdDescent.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), descentHelp)

--- a/cmd/yoke/cmd_descent.go
+++ b/cmd/yoke/cmd_descent.go
@@ -16,64 +16,54 @@ import (
 //go:embed cmd_descent_help.txt
 var descentHelp string
 
-func init() {
-	descentHelp = strings.TrimSpace(internal.Colorize(descentHelp))
-}
-
 type DescentParams struct {
 	GlobalSettings
 	yoke.DescentParams
 }
 
-func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, error) {
+var CmdDescent = NewCommand("descent", []string{"down", "restore"}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
+	params := DescentParams{}
+	var removeAll bool
 	flagset := flag.NewFlagSet("descent", flag.ExitOnError)
-
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), descentHelp)
-		flagset.PrintDefaults()
-	}
-
-	params := DescentParams{
-		GlobalSettings: settings,
-	}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
 
 	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
 	flagset.DurationVar(&params.Wait, "wait", 0, "time to wait for release to become ready")
 	flagset.DurationVar(&params.Poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
 	flagset.BoolVar(&params.Lock, "lock", false, "if enabled does locks release before deploying revision (only prevents other locked runs from running).")
-
-	var removeAll bool
 	flagset.BoolVar(&removeAll, "remove-all", false, "enables pruning of crds and namespaces owned by the release if a new revision would orphan them.\nDestructive and dangerous use with caution.")
 	flagset.BoolVar(&params.RemoveCRDs, "remove-crds", false, "enables pruning of crds owned by the release.\nDestructive and dangerous use with caution.")
 	flagset.BoolVar(&params.RemoveNamespaces, "remove-namespaces", false, "enables pruning of namespaces owned by the release.\nDestructive and dangerous use with caution.")
 
-	flagset.Parse(args)
-
-	if removeAll {
-		params.RemoveCRDs = true
-		params.RemoveNamespaces = true
+	descentHelp = strings.TrimSpace(internal.Colorize(descentHelp))
+	flagset.Usage = func() {
+		fmt.Fprintln(flagset.Output(), descentHelp)
+		flagset.PrintDefaults()
 	}
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
+		params.GlobalSettings = settings
+		RegisterGlobalFlags(flagset, &params.GlobalSettings)
+		flagset.Parse(args)
+		if removeAll {
+			params.RemoveCRDs = true
+			params.RemoveNamespaces = true
+		}
+		params.Release = flagset.Arg(0)
+		if params.Release == "" {
+			return fmt.Errorf("release is required as first positional arg")
+		}
 
-	params.Release = flagset.Arg(0)
-	if params.Release == "" {
-		return nil, fmt.Errorf("release is required as first positional arg")
+		if len(flagset.Args()) < 2 {
+			return fmt.Errorf("revision is required as second positional arg")
+		}
+
+		revisionID, err := strconv.Atoi(flagset.Arg(1))
+		if err != nil {
+			return fmt.Errorf("revision must be an integer ID: %w", err)
+		}
+		params.RevisionID = revisionID
+		return Descent(ctx, params)
 	}
-
-	if len(flagset.Args()) < 2 {
-		return nil, fmt.Errorf("revision is required as second positional arg")
-	}
-
-	revisionID, err := strconv.Atoi(flagset.Arg(1))
-	if err != nil {
-		return nil, fmt.Errorf("revision must be an integer ID: %w", err)
-	}
-
-	params.RevisionID = revisionID
-
-	return &params, nil
-}
+})
 
 func Descent(ctx context.Context, params DescentParams) error {
 	commander, err := yoke.FromKubeConfigFlags(params.Kube)

--- a/cmd/yoke/cmd_descent.go
+++ b/cmd/yoke/cmd_descent.go
@@ -16,8 +16,15 @@ import (
 //go:embed cmd_descent_help.txt
 var descentHelp string
 
+var CmdDescend = &YokeCommand{
+	Name:     "descent",
+	Aliases:  []string{"down", "restore"},
+	FlagsSet: flag.NewFlagSet("descent", flag.ExitOnError),
+}
+
 func init() {
 	descentHelp = strings.TrimSpace(internal.Colorize(descentHelp))
+	CmdRoot.AddCommand(CmdDescend)
 }
 
 type DescentParams struct {
@@ -26,7 +33,7 @@ type DescentParams struct {
 }
 
 func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, error) {
-	flagset := flag.NewFlagSet("descent", flag.ExitOnError)
+	flagset := CmdDescend.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), descentHelp)

--- a/cmd/yoke/cmd_descent.go
+++ b/cmd/yoke/cmd_descent.go
@@ -23,26 +23,19 @@ var CmdDescent = &YokeCommand{
 }
 
 var (
-	release          string
-	revisionID       int
-	namespace        string
-	wait             time.Duration
-	poll             time.Duration
-	lock             bool
-	removeCRDs       bool
-	removeNamespaces bool
-	removeAll        bool
+	descentParams    DescentParams
+	descentRemoveAll bool
 )
 
 func init() {
 	descentHelp = strings.TrimSpace(internal.Colorize(descentHelp))
-	CmdDescent.FlagSet.StringVar(&namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
-	CmdDescent.FlagSet.DurationVar(&wait, "wait", 0, "time to wait for release to become ready")
-	CmdDescent.FlagSet.DurationVar(&poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
-	CmdDescent.FlagSet.BoolVar(&lock, "lock", false, "if enabled does locks release before deploying revision (only prevents other locked runs from running).")
-	CmdDescent.FlagSet.BoolVar(&removeAll, "remove-all", false, "enables pruning of crds and namespaces owned by the release if a new revision would orphan them.\nDestructive and dangerous use with caution.")
-	CmdDescent.FlagSet.BoolVar(&removeCRDs, "remove-crds", false, "enables pruning of crds owned by the release.\nDestructive and dangerous use with caution.")
-	CmdDescent.FlagSet.BoolVar(&removeNamespaces, "remove-namespaces", false, "enables pruning of namespaces owned by the release.\nDestructive and dangerous use with caution.")
+	CmdDescent.FlagSet.StringVar(&descentParams.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
+	CmdDescent.FlagSet.DurationVar(&descentParams.Wait, "wait", 0, "time to wait for release to become ready")
+	CmdDescent.FlagSet.DurationVar(&descentParams.Poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
+	CmdDescent.FlagSet.BoolVar(&descentParams.Lock, "lock", false, "if enabled does locks release before deploying revision (only prevents other locked runs from running).")
+	CmdDescent.FlagSet.BoolVar(&descentRemoveAll, "remove-all", false, "enables pruning of crds and namespaces owned by the release if a new revision would orphan them.\nDestructive and dangerous use with caution.")
+	CmdDescent.FlagSet.BoolVar(&descentParams.RemoveCRDs, "remove-crds", false, "enables pruning of crds owned by the release.\nDestructive and dangerous use with caution.")
+	CmdDescent.FlagSet.BoolVar(&descentParams.RemoveNamespaces, "remove-namespaces", false, "enables pruning of namespaces owned by the release.\nDestructive and dangerous use with caution.")
 	CmdDescent.FlagSet.Usage = func() {
 		fmt.Fprintln(CmdDescent.FlagSet.Output(), descentHelp)
 		CmdDescent.FlagSet.PrintDefaults()
@@ -59,27 +52,19 @@ type DescentParams struct {
 func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, error) {
 	flagset := CmdDescent.FlagSet
 
-	params := DescentParams{
-		GlobalSettings: settings,
-	}
+	descentParams.GlobalSettings = settings
 
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
+	RegisterGlobalFlags(flagset, &descentParams.GlobalSettings)
 
 	flagset.Parse(args)
-	params.Namespace = namespace
-	params.Poll = poll
-	params.Wait = wait
-	params.Lock = lock
-	params.RemoveCRDs = removeCRDs
-	params.RemoveNamespaces = removeNamespaces
 
-	if removeAll {
-		params.RemoveCRDs = true
-		params.RemoveNamespaces = true
+	if descentRemoveAll {
+		descentParams.RemoveCRDs = true
+		descentParams.RemoveNamespaces = true
 	}
 
-	params.Release = flagset.Arg(0)
-	if params.Release == "" {
+	descentParams.Release = flagset.Arg(0)
+	if descentParams.Release == "" {
 		return nil, fmt.Errorf("release is required as first positional arg")
 	}
 
@@ -92,9 +77,9 @@ func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, 
 		return nil, fmt.Errorf("revision must be an integer ID: %w", err)
 	}
 
-	params.RevisionID = revisionID
+	descentParams.RevisionID = revisionID
 
-	return &params, nil
+	return &descentParams, nil
 }
 
 func Descent(ctx context.Context, params DescentParams) error {

--- a/cmd/yoke/cmd_descent.go
+++ b/cmd/yoke/cmd_descent.go
@@ -17,13 +17,37 @@ import (
 var descentHelp string
 
 var CmdDescent = &YokeCommand{
-	Name:     "descent",
-	Aliases:  []string{"down", "restore"},
-	FlagsSet: flag.NewFlagSet("descent", flag.ExitOnError),
+	Name:    "descent",
+	Aliases: []string{"down", "restore"},
+	FlagSet: flag.NewFlagSet("descent", flag.ExitOnError),
 }
+
+var (
+	release          string
+	revisionID       int
+	namespace        string
+	wait             time.Duration
+	poll             time.Duration
+	lock             bool
+	removeCRDs       bool
+	removeNamespaces bool
+	removeAll        bool
+)
 
 func init() {
 	descentHelp = strings.TrimSpace(internal.Colorize(descentHelp))
+	CmdDescent.FlagSet.StringVar(&namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
+	CmdDescent.FlagSet.DurationVar(&wait, "wait", 0, "time to wait for release to become ready")
+	CmdDescent.FlagSet.DurationVar(&poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
+	CmdDescent.FlagSet.BoolVar(&lock, "lock", false, "if enabled does locks release before deploying revision (only prevents other locked runs from running).")
+	CmdDescent.FlagSet.BoolVar(&removeAll, "remove-all", false, "enables pruning of crds and namespaces owned by the release if a new revision would orphan them.\nDestructive and dangerous use with caution.")
+	CmdDescent.FlagSet.BoolVar(&removeCRDs, "remove-crds", false, "enables pruning of crds owned by the release.\nDestructive and dangerous use with caution.")
+	CmdDescent.FlagSet.BoolVar(&removeNamespaces, "remove-namespaces", false, "enables pruning of namespaces owned by the release.\nDestructive and dangerous use with caution.")
+	CmdDescent.FlagSet.Usage = func() {
+		fmt.Fprintln(CmdDescent.FlagSet.Output(), descentHelp)
+		CmdDescent.FlagSet.PrintDefaults()
+	}
+
 	CmdRoot.AddCommand(CmdDescent)
 }
 
@@ -33,12 +57,7 @@ type DescentParams struct {
 }
 
 func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, error) {
-	flagset := CmdDescent.FlagsSet
-
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), descentHelp)
-		flagset.PrintDefaults()
-	}
+	flagset := CmdDescent.FlagSet
 
 	params := DescentParams{
 		GlobalSettings: settings,
@@ -46,17 +65,13 @@ func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, 
 
 	RegisterGlobalFlags(flagset, &params.GlobalSettings)
 
-	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
-	flagset.DurationVar(&params.Wait, "wait", 0, "time to wait for release to become ready")
-	flagset.DurationVar(&params.Poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
-	flagset.BoolVar(&params.Lock, "lock", false, "if enabled does locks release before deploying revision (only prevents other locked runs from running).")
-
-	var removeAll bool
-	flagset.BoolVar(&removeAll, "remove-all", false, "enables pruning of crds and namespaces owned by the release if a new revision would orphan them.\nDestructive and dangerous use with caution.")
-	flagset.BoolVar(&params.RemoveCRDs, "remove-crds", false, "enables pruning of crds owned by the release.\nDestructive and dangerous use with caution.")
-	flagset.BoolVar(&params.RemoveNamespaces, "remove-namespaces", false, "enables pruning of namespaces owned by the release.\nDestructive and dangerous use with caution.")
-
 	flagset.Parse(args)
+	params.Namespace = namespace
+	params.Poll = poll
+	params.Wait = wait
+	params.Lock = lock
+	params.RemoveCRDs = removeCRDs
+	params.RemoveNamespaces = removeNamespaces
 
 	if removeAll {
 		params.RemoveCRDs = true

--- a/cmd/yoke/cmd_help.txt
+++ b/cmd/yoke/cmd_help.txt
@@ -17,5 +17,6 @@ atc
 sign
 verify
 version
+complete
 
 !cyan Global Flags:

--- a/cmd/yoke/cmd_mayday.go
+++ b/cmd/yoke/cmd_mayday.go
@@ -19,12 +19,19 @@ type MaydayParams struct {
 //go:embed cmd_mayday_help.txt
 var maydayHelp string
 
+var CmdMayday = &YokeCommand{
+	Name:     "mayday",
+	Aliases:  []string{"delete"},
+	FlagsSet: flag.NewFlagSet("mayday", flag.ExitOnError),
+}
+
 func init() {
 	maydayHelp = strings.TrimSpace(internal.Colorize(maydayHelp))
+	CmdRoot.AddCommand(CmdMayday)
 }
 
 func GetMaydayParams(settings GlobalSettings, args []string) (*MaydayParams, error) {
-	flagset := flag.NewFlagSet("mayday", flag.ExitOnError)
+	flagset := CmdMayday.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), maydayHelp)

--- a/cmd/yoke/cmd_mayday.go
+++ b/cmd/yoke/cmd_mayday.go
@@ -19,43 +19,36 @@ type MaydayParams struct {
 //go:embed cmd_mayday_help.txt
 var maydayHelp string
 
-func init() {
-	maydayHelp = strings.TrimSpace(internal.Colorize(maydayHelp))
-}
-
-func GetMaydayParams(settings GlobalSettings, args []string) (*MaydayParams, error) {
+var CmdMayday = NewCommand("mayday", []string{"delete"}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
 	flagset := flag.NewFlagSet("mayday", flag.ExitOnError)
-
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), maydayHelp)
-		flagset.PrintDefaults()
-	}
-
-	params := MaydayParams{GlobalSettings: settings}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
-
-	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
-
 	var removeAll bool
+	params := MaydayParams{}
+	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
 	flagset.BoolVar(&removeAll, "remove-all", false, "deletes crds and namespaces owned by the release. Destructive and dangerous use with caution.")
 	flagset.BoolVar(&params.RemoveCRDs, "remove-crds", false, "deletes crds owned by the release. Destructive and dangerous use with caution.")
 	flagset.BoolVar(&params.RemoveNamespaces, "remove-namespaces", false, "deletes namespaces owned by the release. Destructive and dangerous use with caution.")
 
-	flagset.Parse(args)
-
-	if removeAll {
-		params.RemoveCRDs = true
-		params.RemoveNamespaces = true
+	flagset.Usage = func() {
+		maydayHelp = strings.TrimSpace(internal.Colorize(maydayHelp))
+		fmt.Fprintln(flagset.Output(), maydayHelp)
+		flagset.PrintDefaults()
 	}
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
+		params.GlobalSettings = settings
+		RegisterGlobalFlags(flagset, &params.GlobalSettings)
 
-	params.Release = flagset.Arg(0)
-	if params.Release == "" {
-		return nil, fmt.Errorf("release is required")
+		flagset.Parse(args)
+		if removeAll {
+			params.RemoveCRDs = true
+			params.RemoveNamespaces = true
+		}
+		params.Release = flagset.Arg(0)
+		if params.Release == "" {
+			return fmt.Errorf("release is required")
+		}
+		return Mayday(ctx, params)
 	}
-
-	return &params, nil
-}
+})
 
 func Mayday(ctx context.Context, params MaydayParams) error {
 	commander, err := yoke.FromKubeConfigFlags(params.Kube)

--- a/cmd/yoke/cmd_mayday.go
+++ b/cmd/yoke/cmd_mayday.go
@@ -20,9 +20,9 @@ type MaydayParams struct {
 var maydayHelp string
 
 var CmdMayday = &YokeCommand{
-	Name:     "mayday",
-	Aliases:  []string{"delete"},
-	FlagsSet: flag.NewFlagSet("mayday", flag.ExitOnError),
+	Name:    "mayday",
+	Aliases: []string{"delete"},
+	FlagSet: flag.NewFlagSet("mayday", flag.ExitOnError),
 }
 
 func init() {
@@ -31,7 +31,7 @@ func init() {
 }
 
 func GetMaydayParams(settings GlobalSettings, args []string) (*MaydayParams, error) {
-	flagset := CmdMayday.FlagsSet
+	flagset := CmdMayday.FlagSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), maydayHelp)

--- a/cmd/yoke/cmd_mayday.go
+++ b/cmd/yoke/cmd_mayday.go
@@ -24,34 +24,37 @@ var CmdMayday = &YokeCommand{
 	Aliases: []string{"delete"},
 	FlagSet: flag.NewFlagSet("mayday", flag.ExitOnError),
 }
+var (
+	maydayNamespace        string
+	maydayRemoveAll        bool
+	maydayRemoveCRDs       bool
+	maydayRemoveNamespaces bool
+)
 
 func init() {
 	maydayHelp = strings.TrimSpace(internal.Colorize(maydayHelp))
+	CmdMayday.FlagSet.StringVar(&maydayNamespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
+	CmdMayday.FlagSet.BoolVar(&maydayRemoveAll, "remove-all", false, "deletes crds and namespaces owned by the release. Destructive and dangerous use with caution.")
+	CmdMayday.FlagSet.BoolVar(&maydayRemoveCRDs, "remove-crds", false, "deletes crds owned by the release. Destructive and dangerous use with caution.")
+	CmdMayday.FlagSet.BoolVar(&maydayRemoveNamespaces, "remove-namespaces", false, "deletes namespaces owned by the release. Destructive and dangerous use with caution.")
+
+	CmdMayday.FlagSet.Usage = func() {
+		fmt.Fprintln(CmdMayday.FlagSet.Output(), maydayHelp)
+		CmdMayday.FlagSet.PrintDefaults()
+	}
 	CmdRoot.AddCommand(CmdMayday)
 }
 
 func GetMaydayParams(settings GlobalSettings, args []string) (*MaydayParams, error) {
 	flagset := CmdMayday.FlagSet
 
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), maydayHelp)
-		flagset.PrintDefaults()
-	}
-
 	params := MaydayParams{GlobalSettings: settings}
 
 	RegisterGlobalFlags(flagset, &params.GlobalSettings)
 
-	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
-
-	var removeAll bool
-	flagset.BoolVar(&removeAll, "remove-all", false, "deletes crds and namespaces owned by the release. Destructive and dangerous use with caution.")
-	flagset.BoolVar(&params.RemoveCRDs, "remove-crds", false, "deletes crds owned by the release. Destructive and dangerous use with caution.")
-	flagset.BoolVar(&params.RemoveNamespaces, "remove-namespaces", false, "deletes namespaces owned by the release. Destructive and dangerous use with caution.")
-
 	flagset.Parse(args)
 
-	if removeAll {
+	if maydayRemoveAll {
 		params.RemoveCRDs = true
 		params.RemoveNamespaces = true
 	}

--- a/cmd/yoke/cmd_schematics.go
+++ b/cmd/yoke/cmd_schematics.go
@@ -15,12 +15,19 @@ import (
 //go:embed cmd_schematics_help.txt
 var schematicsHelp string
 
+var CmdSchematics = &YokeCommand{
+	Name:     "schematics",
+	Aliases:  []string{"meta"},
+	FlagsSet: flag.NewFlagSet("schematics", flag.ExitOnError),
+}
+
 func init() {
 	schematicsHelp = strings.TrimSpace(internal.Colorize(schematicsHelp))
+	CmdRoot.AddCommand(CmdSchematics)
 }
 
 func SchematicsCommand(ctx context.Context, args []string) error {
-	flagset := flag.NewFlagSet("schematics", flag.ExitOnError)
+	flagset := CmdSchematics.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), schematicsHelp)

--- a/cmd/yoke/cmd_schematics.go
+++ b/cmd/yoke/cmd_schematics.go
@@ -15,6 +15,7 @@ import (
 //go:embed cmd_schematics_help.txt
 var schematicsHelp string
 
+var schematicsWasmPath string
 var CmdSchematics = &YokeCommand{
 	Name:    "schematics",
 	Aliases: []string{"meta"},
@@ -23,23 +24,21 @@ var CmdSchematics = &YokeCommand{
 
 func init() {
 	schematicsHelp = strings.TrimSpace(internal.Colorize(schematicsHelp))
+	CmdSchematics.FlagSet.StringVar(&schematicsWasmPath, "wasm", "", "path to wasm file. http(s), and oci urls are supported")
+
+	CmdSchematics.FlagSet.Usage = func() {
+		fmt.Fprintln(CmdSchematics.FlagSet.Output(), schematicsHelp)
+		CmdSchematics.FlagSet.PrintDefaults()
+	}
 	CmdRoot.AddCommand(CmdSchematics)
 }
 
 func SchematicsCommand(ctx context.Context, args []string) error {
 	flagset := CmdSchematics.FlagSet
 
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), schematicsHelp)
-		flagset.PrintDefaults()
-	}
-
-	var wasmPath string
-	flagset.StringVar(&wasmPath, "wasm", "", "path to wasm file. http(s), and oci urls are supported")
-
 	flagset.Parse(args)
 
-	if wasmPath == "" {
+	if schematicsWasmPath == "" {
 		flagset.Usage()
 		return fmt.Errorf("--wasm is required")
 	}
@@ -51,10 +50,11 @@ func SchematicsCommand(ctx context.Context, args []string) error {
 
 	subcmd, subargs := flagset.Arg(0), flagset.Args()[1:]
 
+	// TODO: handle the schematics subcommand as a YokeCommand
 	switch subcmd {
 	case "ls":
 		{
-			schematics, err := yoke.ListSchematics(ctx, yoke.ListSchematicsParams{WasmURL: wasmPath})
+			schematics, err := yoke.ListSchematics(ctx, yoke.ListSchematicsParams{WasmURL: schematicsWasmPath})
 			if err != nil {
 				return fmt.Errorf("failed to list schematics: %w", err)
 			}
@@ -69,7 +69,7 @@ func SchematicsCommand(ctx context.Context, args []string) error {
 				return fmt.Errorf("name of schematics property is required")
 			}
 			data, err := yoke.GetSchematic(ctx, yoke.GetSchematicParams{
-				WasmURL: wasmPath,
+				WasmURL: schematicsWasmPath,
 				Name:    subargs[0],
 			})
 			if err != nil {
@@ -96,7 +96,7 @@ func SchematicsCommand(ctx context.Context, args []string) error {
 			}
 
 			return yoke.SetSchematic(ctx, yoke.SetSchematicParams{
-				WasmPath: wasmPath,
+				WasmPath: schematicsWasmPath,
 				Name:     name,
 				Input:    os.Stdin,
 				CMD:      *cmd,

--- a/cmd/yoke/cmd_schematics.go
+++ b/cmd/yoke/cmd_schematics.go
@@ -6,96 +6,141 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/yokecd/yoke/internal"
 	"github.com/yokecd/yoke/pkg/yoke"
 )
 
+func init() {
+	CmdSchematics.AddCommand(CmdSchematicsGet)
+	CmdSchematics.AddCommand(CmdSchematicsLs)
+	CmdSchematics.AddCommand(CmdSchematicsSet)
+}
+
 //go:embed cmd_schematics_help.txt
 var schematicsHelp string
 
-func init() {
-	schematicsHelp = strings.TrimSpace(internal.Colorize(schematicsHelp))
-}
-
-func SchematicsCommand(ctx context.Context, args []string) error {
+var CmdSchematics = NewCommand("schematics", []string{"meta"}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
 	flagset := flag.NewFlagSet("schematics", flag.ExitOnError)
-
+	var wasmPath string
+	flagset.StringVar(&wasmPath, "wasm", "", "path to wasm file. http(s), and oci urls are supported")
 	flagset.Usage = func() {
+		schematicsHelp = strings.TrimSpace(internal.Colorize(schematicsHelp))
 		fmt.Fprintln(flagset.Output(), schematicsHelp)
 		flagset.PrintDefaults()
 	}
 
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
+		flagset.Parse(args)
+		return fmt.Errorf("subcommand is required")
+	}
+})
+
+var CmdSchematicsLs = NewCommand("ls", []string{}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
+	flagset := flag.NewFlagSet("schematics ls", flag.ExitOnError)
 	var wasmPath string
 	flagset.StringVar(&wasmPath, "wasm", "", "path to wasm file. http(s), and oci urls are supported")
-
-	flagset.Parse(args)
-
-	if wasmPath == "" {
+	flagset.Usage = func() {
 		flagset.Usage()
-		return fmt.Errorf("--wasm is required")
+		flagset.PrintDefaults()
 	}
+	return flagset, func(ctx context.Context, settings GlobalSettings, _ []string) error {
+		// This is so incredibily janky, but I can't think of another way to do this
+		args := os.Args
+		idxBase := slices.Index(args, "schematics")
+		if idxBase >= 0 {
+			args = os.Args[idxBase+1:]
+		} else {
+			return fmt.Errorf("orphaned subcommand")
+		}
 
-	if len(flagset.Args()) == 0 {
+		flagset.Parse(args)
+		schematics, err := yoke.ListSchematics(ctx, yoke.ListSchematicsParams{WasmURL: wasmPath})
+		if err != nil {
+			return fmt.Errorf("failed to list schematics: %w", err)
+		}
+		for _, schematic := range schematics {
+			fmt.Fprintln(internal.Stdout(ctx), schematic)
+		}
+		return nil
+	}
+})
+
+var CmdSchematicsGet = NewCommand("get", []string{}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
+	flagset := flag.NewFlagSet("get", flag.ExitOnError)
+
+	var wasmPath string
+	flagset.StringVar(&wasmPath, "wasm", "", "path to wasm file. http(s), and oci urls are supported")
+	flagset.Usage = func() {
 		flagset.Usage()
-		return fmt.Errorf("no subcommand given to schematics")
+		flagset.PrintDefaults()
 	}
 
-	subcmd, subargs := flagset.Arg(0), flagset.Args()[1:]
-
-	switch subcmd {
-	case "ls":
-		{
-			schematics, err := yoke.ListSchematics(ctx, yoke.ListSchematicsParams{WasmURL: wasmPath})
-			if err != nil {
-				return fmt.Errorf("failed to list schematics: %w", err)
-			}
-			for _, schematic := range schematics {
-				fmt.Fprintln(internal.Stdout(ctx), schematic)
-			}
-			return nil
+	return flagset, func(ctx context.Context, settings GlobalSettings, _ []string) error {
+		args := os.Args
+		idxBase := slices.Index(args, "schematics")
+		if idxBase >= 0 {
+			args = os.Args[idxBase+1:]
+		} else {
+			return fmt.Errorf("orphaned subcommand")
 		}
-	case "get":
-		{
-			if len(subargs) == 0 || subargs[0] == "" {
-				return fmt.Errorf("name of schematics property is required")
-			}
-			data, err := yoke.GetSchematic(ctx, yoke.GetSchematicParams{
-				WasmURL: wasmPath,
-				Name:    subargs[0],
-			})
-			if err != nil {
-				return fmt.Errorf("failed to get schematics: %w", err)
-			}
-			_, err = internal.Stdout(ctx).Write(data)
-			return err
+		flagset.Parse(args)
+		idxGet := slices.Index(flagset.Args(), "get")
+		name := ""
+		if idxGet >= 0 {
+			name = flagset.Arg(idxGet + 1)
 		}
-	case "set":
-		{
-			setcmdFlagset := flag.NewFlagSet("schematics set", flag.ExitOnError)
-			cmd := setcmdFlagset.Bool("cmd", false, "marks the input as command args to be executed to generate the schematic data")
-
-			setcmdFlagset.Usage = func() {
-				flagset.Usage()
-				setcmdFlagset.PrintDefaults()
-			}
-
-			_ = setcmdFlagset.Parse(subargs)
-
-			name := setcmdFlagset.Arg(0)
-			if name == "" {
-				return fmt.Errorf("name of schematics property is required")
-			}
-
-			return yoke.SetSchematic(ctx, yoke.SetSchematicParams{
-				WasmPath: wasmPath,
-				Name:     name,
-				Input:    os.Stdin,
-				CMD:      *cmd,
-			})
+		if name == "" {
+			return fmt.Errorf("name of schematics property is required")
 		}
-	default:
-		return fmt.Errorf("unknown schematics subcommand: %q", subcmd)
+		data, err := yoke.GetSchematic(ctx, yoke.GetSchematicParams{
+			WasmURL: wasmPath,
+			Name:    name,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get schematics: %w", err)
+		}
+		_, err = internal.Stdout(ctx).Write(data)
+		return err
 	}
-}
+})
+
+var CmdSchematicsSet = NewCommand("set", []string{}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
+	flagset := flag.NewFlagSet("set", flag.ExitOnError)
+	cmd := flagset.Bool("cmd", false, "marks the input as command args to be executed to generate the schematic data")
+
+	var wasmPath string
+	flagset.StringVar(&wasmPath, "wasm", "", "path to wasm file. http(s), and oci urls are supported")
+	flagset.Usage = func() {
+		flagset.Usage()
+		flagset.PrintDefaults()
+	}
+
+	return flagset, func(ctx context.Context, settings GlobalSettings, _ []string) error {
+		args := os.Args
+		idxBase := slices.Index(args, "schematics")
+		if idxBase >= 0 {
+			args = os.Args[idxBase+1:]
+		} else {
+			return fmt.Errorf("orphaned subcommand")
+		}
+
+		_ = flagset.Parse(args)
+		idxGet := slices.Index(flagset.Args(), "set")
+		name := ""
+		if idxGet >= 0 {
+			name = flagset.Arg(idxGet + 1)
+		}
+		if name == "" {
+			return fmt.Errorf("name of schematics property is required")
+		}
+		return yoke.SetSchematic(ctx, yoke.SetSchematicParams{
+			WasmPath: wasmPath,
+			Name:     name,
+			Input:    os.Stdin,
+			CMD:      *cmd,
+		})
+	}
+})

--- a/cmd/yoke/cmd_schematics.go
+++ b/cmd/yoke/cmd_schematics.go
@@ -16,9 +16,9 @@ import (
 var schematicsHelp string
 
 var CmdSchematics = &YokeCommand{
-	Name:     "schematics",
-	Aliases:  []string{"meta"},
-	FlagsSet: flag.NewFlagSet("schematics", flag.ExitOnError),
+	Name:    "schematics",
+	Aliases: []string{"meta"},
+	FlagSet: flag.NewFlagSet("schematics", flag.ExitOnError),
 }
 
 func init() {
@@ -27,7 +27,7 @@ func init() {
 }
 
 func SchematicsCommand(ctx context.Context, args []string) error {
-	flagset := CmdSchematics.FlagsSet
+	flagset := CmdSchematics.FlagSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), schematicsHelp)

--- a/cmd/yoke/cmd_sign.go
+++ b/cmd/yoke/cmd_sign.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	_ "embed"
 	"flag"
 	"fmt"
@@ -13,33 +14,29 @@ import (
 //go:embed cmd_sign_help.txt
 var signHelp string
 
-func init() {
-	signHelp = strings.TrimSpace(internal.Colorize(signHelp))
-}
-
-func GetSignParams(args []string) (*yoke.SignParams, error) {
+var CmdSign = NewCommand("sign", []string{}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
 	flagset := flag.NewFlagSet("sign", flag.ExitOnError)
-
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), signHelp)
-		flagset.PrintDefaults()
-	}
-
-	var params yoke.SignParams
+	params := yoke.SignParams{}
 	flagset.StringVar(&params.KeyPath, "key", "", "Path to private key pem used for signing")
 	flagset.StringVar(&params.Out, "o", "", "output file to write signed wasm module. If omitted module will be signed in place")
 	flagset.BoolVar(&params.Force, "f", false, "forcefully override existing signature on module")
-
-	flagset.Parse(args)
-
-	params.WasmFile = flagset.Arg(0)
-
-	if params.WasmFile == "" {
-		return nil, fmt.Errorf("wasm file must be specified as first argument")
+	flagset.Usage = func() {
+		signHelp = strings.TrimSpace(internal.Colorize(signHelp))
+		fmt.Fprintln(flagset.Output(), signHelp)
+		flagset.PrintDefaults()
 	}
-	if params.KeyPath == "" {
-		return nil, fmt.Errorf("key is required")
-	}
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
 
-	return &params, nil
-}
+		flagset.Parse(args)
+
+		params.WasmFile = flagset.Arg(0)
+
+		if params.WasmFile == "" {
+			return fmt.Errorf("wasm file must be specified as first argument")
+		}
+		if params.KeyPath == "" {
+			return fmt.Errorf("key is required")
+		}
+		return yoke.Sign(params)
+	}
+})

--- a/cmd/yoke/cmd_sign.go
+++ b/cmd/yoke/cmd_sign.go
@@ -14,8 +14,8 @@ import (
 var signHelp string
 
 var CmdSign = &YokeCommand{
-	Name:     "sign",
-	FlagsSet: flag.NewFlagSet("sign", flag.ExitOnError),
+	Name:    "sign",
+	FlagSet: flag.NewFlagSet("sign", flag.ExitOnError),
 }
 
 func init() {
@@ -24,7 +24,7 @@ func init() {
 }
 
 func GetSignParams(args []string) (*yoke.SignParams, error) {
-	flagset := CmdSign.FlagsSet
+	flagset := CmdSign.FlagSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), signHelp)

--- a/cmd/yoke/cmd_sign.go
+++ b/cmd/yoke/cmd_sign.go
@@ -13,12 +13,18 @@ import (
 //go:embed cmd_sign_help.txt
 var signHelp string
 
+var CmdSign = &YokeCommand{
+	Name:     "sign",
+	FlagsSet: flag.NewFlagSet("sign", flag.ExitOnError),
+}
+
 func init() {
 	signHelp = strings.TrimSpace(internal.Colorize(signHelp))
+	CmdRoot.AddCommand(CmdSign)
 }
 
 func GetSignParams(args []string) (*yoke.SignParams, error) {
-	flagset := flag.NewFlagSet("sign", flag.ExitOnError)
+	flagset := CmdSign.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), signHelp)

--- a/cmd/yoke/cmd_sign.go
+++ b/cmd/yoke/cmd_sign.go
@@ -18,23 +18,33 @@ var CmdSign = &YokeCommand{
 	FlagSet: flag.NewFlagSet("sign", flag.ExitOnError),
 }
 
+var (
+	signKeyPath string
+	signOut     string
+	signForce   bool
+)
+
 func init() {
 	signHelp = strings.TrimSpace(internal.Colorize(signHelp))
+
+	CmdSign.FlagSet.StringVar(&signKeyPath, "key", "", "Path to private key pem used for signing")
+	CmdSign.FlagSet.StringVar(&signOut, "o", "", "output file to write signed wasm module. If omitted module will be signed in place")
+	CmdSign.FlagSet.BoolVar(&signForce, "f", false, "forcefully override existing signature on module")
+	CmdSign.FlagSet.Usage = func() {
+		fmt.Fprintln(CmdSign.FlagSet.Output(), signHelp)
+		CmdSign.FlagSet.PrintDefaults()
+	}
 	CmdRoot.AddCommand(CmdSign)
 }
 
 func GetSignParams(args []string) (*yoke.SignParams, error) {
 	flagset := CmdSign.FlagSet
 
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), signHelp)
-		flagset.PrintDefaults()
+	params := yoke.SignParams{
+		KeyPath: signKeyPath,
+		Out:     signOut,
+		Force:   signForce,
 	}
-
-	var params yoke.SignParams
-	flagset.StringVar(&params.KeyPath, "key", "", "Path to private key pem used for signing")
-	flagset.StringVar(&params.Out, "o", "", "output file to write signed wasm module. If omitted module will be signed in place")
-	flagset.BoolVar(&params.Force, "f", false, "forcefully override existing signature on module")
 
 	flagset.Parse(args)
 

--- a/cmd/yoke/cmd_stow.go
+++ b/cmd/yoke/cmd_stow.go
@@ -13,12 +13,19 @@ import (
 //go:embed cmd_stow_help.txt
 var stowHelp string
 
+var CmdStow = &YokeCommand{
+	Name:     "stow",
+	Aliases:  []string{"push"},
+	FlagsSet: flag.NewFlagSet("stow", flag.ExitOnError),
+}
+
 func init() {
 	stowHelp = strings.TrimSpace(internal.Colorize(stowHelp))
+	CmdRoot.AddCommand(CmdStow)
 }
 
 func GetStowParams(args []string) (*yoke.StowParams, error) {
-	flagset := flag.NewFlagSet("stow", flag.ExitOnError)
+	flagset := CmdStow.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), stowHelp)

--- a/cmd/yoke/cmd_stow.go
+++ b/cmd/yoke/cmd_stow.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	_ "embed"
 	"flag"
 	"fmt"
@@ -13,36 +14,32 @@ import (
 //go:embed cmd_stow_help.txt
 var stowHelp string
 
-func init() {
-	stowHelp = strings.TrimSpace(internal.Colorize(stowHelp))
-}
-
-func GetStowParams(args []string) (*yoke.StowParams, error) {
+var CmdStow = NewCommand("stow", []string{"push"}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
 	flagset := flag.NewFlagSet("stow", flag.ExitOnError)
-
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), stowHelp)
-		flagset.PrintDefaults()
-	}
-
-	var params yoke.StowParams
+	params := yoke.StowParams{}
 
 	flagset.BoolVar(&params.Insecure, "insecure", false, "allows image references to be fetched without TLS")
 	flagset.Func("tag", "comma separated list of tags", func(s string) error {
 		params.Tags = append(params.Tags, strings.Split(s, ",")...)
 		return nil
 	})
-	flagset.Parse(args)
-
-	params.WasmFile = flagset.Arg(0)
-	params.URL = flagset.Arg(1)
-
-	if params.WasmFile == "" {
-		return nil, fmt.Errorf("wasm file must be specified as first argument")
-	}
-	if params.URL == "" {
-		return nil, fmt.Errorf("OCI url must be specified as second argument")
+	flagset.Usage = func() {
+		stowHelp = strings.TrimSpace(internal.Colorize(stowHelp))
+		fmt.Fprintln(flagset.Output(), stowHelp)
+		flagset.PrintDefaults()
 	}
 
-	return &params, nil
-}
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
+		flagset.Parse(args)
+		params.WasmFile = flagset.Arg(0)
+		params.URL = flagset.Arg(1)
+
+		if params.WasmFile == "" {
+			return fmt.Errorf("wasm file must be specified as first argument")
+		}
+		if params.URL == "" {
+			return fmt.Errorf("OCI url must be specified as second argument")
+		}
+		return yoke.Stow(ctx, params)
+	}
+})

--- a/cmd/yoke/cmd_stow.go
+++ b/cmd/yoke/cmd_stow.go
@@ -14,9 +14,9 @@ import (
 var stowHelp string
 
 var CmdStow = &YokeCommand{
-	Name:     "stow",
-	Aliases:  []string{"push"},
-	FlagsSet: flag.NewFlagSet("stow", flag.ExitOnError),
+	Name:    "stow",
+	Aliases: []string{"push"},
+	FlagSet: flag.NewFlagSet("stow", flag.ExitOnError),
 }
 
 func init() {
@@ -25,7 +25,7 @@ func init() {
 }
 
 func GetStowParams(args []string) (*yoke.StowParams, error) {
-	flagset := CmdStow.FlagsSet
+	flagset := CmdStow.FlagSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), stowHelp)

--- a/cmd/yoke/cmd_stow.go
+++ b/cmd/yoke/cmd_stow.go
@@ -19,8 +19,18 @@ var CmdStow = &YokeCommand{
 	FlagSet: flag.NewFlagSet("stow", flag.ExitOnError),
 }
 
+var (
+	stowInsecure bool
+	stowTags     []string
+)
+
 func init() {
 	stowHelp = strings.TrimSpace(internal.Colorize(stowHelp))
+	CmdStow.FlagSet.BoolVar(&stowInsecure, "insecure", false, "allows image references to be fetched without TLS")
+	CmdStow.FlagSet.Func("tag", "comma separated list of tags", func(s string) error {
+		stowTags = append(stowTags, strings.Split(s, ",")...)
+		return nil
+	})
 	CmdRoot.AddCommand(CmdStow)
 }
 
@@ -34,12 +44,9 @@ func GetStowParams(args []string) (*yoke.StowParams, error) {
 
 	var params yoke.StowParams
 
-	flagset.BoolVar(&params.Insecure, "insecure", false, "allows image references to be fetched without TLS")
-	flagset.Func("tag", "comma separated list of tags", func(s string) error {
-		params.Tags = append(params.Tags, strings.Split(s, ",")...)
-		return nil
-	})
 	flagset.Parse(args)
+	params.Insecure = stowInsecure
+	params.Tags = stowTags
 
 	params.WasmFile = flagset.Arg(0)
 	params.URL = flagset.Arg(1)

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -24,26 +24,11 @@ type TakeoffParams struct {
 //go:embed cmd_takeoff_help.txt
 var takeoffHelp string
 
-func init() {
-	takeoffHelp = strings.TrimSpace(internal.Colorize(takeoffHelp))
-}
+var CmdTakeoff = NewCommand("takeoff", []string{"up", "apply"}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
 
-func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) (*TakeoffParams, error) {
 	flagset := flag.NewFlagSet("takeoff", flag.ExitOnError)
-
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), takeoffHelp)
-		flagset.PrintDefaults()
-	}
-
-	params := TakeoffParams{
-		GlobalSettings: settings,
-		TakeoffParams: yoke.TakeoffParams{
-			Flight: yoke.FlightParams{Input: source},
-		},
-	}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
+	params := TakeoffParams{}
+	removeAll := false
 
 	flagset.BoolVar(&params.SendToStdout, "stdout", false, "execute the underlying wasm and outputs it to stdout but does not apply any resources to the cluster")
 	flagset.BoolVar(&params.DryRun, "dry", false, "only call the kubernetes api with dry-run; takes precedence over skip-dry-run.")
@@ -72,7 +57,6 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 	flagset.StringVar(&params.Flight.CompilationCacheDir, "compilation-cache", "", "location to cache wasm compilations")
 	flagset.StringVar(&params.Checksum, "checksum", "", "sha256 checksum for desired module. If module does not match checksum takeoff will fail. Checksum can be inferred from oci tag or from  http basepath")
 	flagset.StringVar(&params.VerifyKeyPath, "verify", "", "path to public key or directory of keys to verify module signature against.")
-
 	flagset.Func(
 		"resource-access",
 		"allows flights with cluster-access to read resources outside of the release that match pattern. This flag can be set many times and matchers can be comma separated.",
@@ -81,33 +65,46 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 			return nil
 		},
 	)
-
-	var removeAll bool
 	flagset.BoolVar(&removeAll, "remove-all", false, "enables pruning of crds and namespaces owned by the release if a new revision would orphan them.\nDestructive and dangerous use with caution.")
 	flagset.BoolVar(&params.RemoveCRDs, "remove-crds", false, "enables pruning of crds owned by the release.\nDestructive and dangerous use with caution.")
 	flagset.BoolVar(&params.RemoveNamespaces, "remove-namespaces", false, "enables pruning of namespaces owned by the release.\nDestructive and dangerous use with caution.")
-
-	args, params.Flight.Args = internal.CutArgs(args)
-
-	flagset.Parse(args)
-
-	if removeAll {
-		params.RemoveCRDs = true
-		params.RemoveNamespaces = true
+	flagset.Usage = func() {
+		takeoffHelp = strings.TrimSpace(internal.Colorize(takeoffHelp))
+		fmt.Fprintln(flagset.Output(), takeoffHelp)
+		flagset.PrintDefaults()
 	}
 
-	params.Release = flagset.Arg(0)
-	params.Flight.Path = flagset.Arg(1)
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
+		var source io.Reader
+		if !term.IsTerminal(int(os.Stdin.Fd())) {
+			source = os.Stdin
+		}
+		params.Flight = yoke.FlightParams{Input: source}
+		params.Kube = settings.Kube
+		RegisterGlobalFlags(flagset, &settings)
 
-	if params.Release == "" {
-		return nil, fmt.Errorf("release is required as first positional arg")
-	}
-	if params.Flight.Input == nil && params.Flight.Path == "" {
-		return nil, fmt.Errorf("flight-path is required as second position arg")
-	}
+		args, params.Flight.Args = internal.CutArgs(args)
 
-	return &params, nil
-}
+		flagset.Parse(args)
+
+		if removeAll {
+			params.RemoveCRDs = true
+			params.RemoveNamespaces = true
+		}
+
+		params.Release = flagset.Arg(0)
+		params.Flight.Path = flagset.Arg(1)
+
+		if params.Release == "" {
+			return fmt.Errorf("release is required as first positional arg")
+		}
+		if params.Flight.Input == nil && params.Flight.Path == "" {
+			return fmt.Errorf("flight-path is required as second position arg")
+		}
+
+		return TakeOff(ctx, params)
+	}
+})
 
 func TakeOff(ctx context.Context, params TakeoffParams) error {
 	commander, err := yoke.FromKubeConfigFlags(params.Kube)

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -25,9 +25,9 @@ type TakeoffParams struct {
 var takeoffHelp string
 
 var CmdTakeoff = &YokeCommand{
-	Name:     "takeoff",
-	Aliases:  []string{"up", "apply"},
-	FlagsSet: flag.NewFlagSet("takeoff", flag.ExitOnError),
+	Name:    "takeoff",
+	Aliases: []string{"up", "apply"},
+	FlagSet: flag.NewFlagSet("takeoff", flag.ExitOnError),
 }
 
 func init() {
@@ -36,7 +36,7 @@ func init() {
 }
 
 func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) (*TakeoffParams, error) {
-	flagset := CmdTakeoff.FlagsSet
+	flagset := CmdTakeoff.FlagSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), takeoffHelp)

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -30,90 +30,84 @@ var CmdTakeoff = &YokeCommand{
 	FlagSet: flag.NewFlagSet("takeoff", flag.ExitOnError),
 }
 
+var takeoffParams = TakeoffParams{}
+var takeoffRemoveAll bool
+
 func init() {
 	takeoffHelp = strings.TrimSpace(internal.Colorize(takeoffHelp))
+	takeoffParams.GlobalSettings = settings
+	flagset := CmdTakeoff.FlagSet
+
+	flagset.BoolVar(&takeoffParams.SendToStdout, "stdout", false, "execute the underlying wasm and outputs it to stdout but does not apply any resources to the cluster")
+	flagset.BoolVar(&takeoffParams.DryRun, "dry", false, "only call the kubernetes api with dry-run; takes precedence over skip-dry-run.")
+	flagset.BoolVar(&takeoffParams.SkipDryRun, "skip-dry-run", false, "disables running dry run to resources before applying them; ineffective if dry-run is true")
+	flagset.BoolVar(&takeoffParams.ForceConflicts, "force-conflicts", false, "force apply changes on field manager conflicts")
+	flagset.BoolVar(&takeoffParams.ForceOwnership, "force-ownership", false, "take ownership of resources during takeoff of resources even if they belong to another release")
+
+	flagset.BoolVar(&takeoffParams.Lock, "lock", false, "if enabled does locks release before deploying revision (only prevents other locked runs from running).")
+	flagset.BoolVar(&takeoffParams.CreateNamespace, "create-namespace", false, "create namespace of target release if not present")
+	flagset.BoolVar(&takeoffParams.CrossNamespace, "cross-namespace", false, "allows releases to create resources in other namespaces than the target namespace")
+	flagset.BoolVar(&takeoffParams.ClusterAccess.Enabled, "cluster-access", false, "allows flight access to the cluster during takeoff. Only applies when not directing output to stdout or to a local destination.")
+	flagset.BoolVar(&takeoffParams.Flight.Insecure, "insecure", false, "allows image references to be fetched without TLS (only applies to oci urls)")
+	flagset.Uint64Var(&takeoffParams.Flight.MaxMemoryMib, "max-memory-mib", 128, "max memory a flight is allowed to allocate at runtime. Max is 4096.")
+	flagset.DurationVar(&takeoffParams.Flight.Timeout, "timeout", 10*time.Second, "timeout for flight execution. Setting to 0 keeps the default 10 seconds. To remove timeouts completely use a negative duration")
+
+	flagset.BoolVar(&takeoffParams.DiffOnly, "diff-only", false, "show diff between current revision and would be applied state. Does not apply anything to cluster")
+	flagset.BoolVar(&takeoffParams.Color, "color", term.IsTerminal(int(os.Stdout.Fd())), "use colored output in diffs")
+	flagset.IntVar(&takeoffParams.Context, "context", 4, "number of lines of context in diff (ignored if not using --diff-only)")
+	flagset.StringVar(&takeoffParams.Out, "out", "", "if present outputs flight resources to directory specified, if out is - outputs to standard out")
+	flagset.StringVar(&takeoffParams.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
+	flagset.DurationVar(&takeoffParams.Wait, "wait", 0, "time to wait for release to be ready")
+	flagset.DurationVar(&takeoffParams.Poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
+
+	flagset.IntVar(&takeoffParams.HistoryCapSize, "history-cap", 10, "max number of revisions to keep in release history. 0 or less is unbounded.")
+
+	flagset.StringVar(&takeoffParams.Flight.CompilationCacheDir, "compilation-cache", "", "location to cache wasm compilations")
+	flagset.StringVar(&takeoffParams.Checksum, "checksum", "", "sha256 checksum for desired module. If module does not match checksum takeoff will fail. Checksum can be inferred from oci tag or from  http basepath")
+	flagset.StringVar(&takeoffParams.VerifyKeyPath, "verify", "", "path to public key or directory of keys to verify module signature against.")
+	flagset.Func(
+		"resource-access",
+		"allows flights with cluster-access to read resources outside of the release that match pattern. This flag can be set many times and matchers can be comma separated.",
+		func(s string) error {
+			takeoffParams.ClusterAccess.ResourceMatchers = append(takeoffParams.ClusterAccess.ResourceMatchers, strings.Split(s, ",")...)
+			return nil
+		},
+	)
+	flagset.BoolVar(&takeoffRemoveAll, "remove-all", false, "enables pruning of crds and namespaces owned by the release if a new revision would orphan them.\nDestructive and dangerous use with caution.")
+	flagset.BoolVar(&takeoffParams.RemoveCRDs, "remove-crds", false, "enables pruning of crds owned by the release.\nDestructive and dangerous use with caution.")
+	flagset.BoolVar(&takeoffParams.RemoveNamespaces, "remove-namespaces", false, "enables pruning of namespaces owned by the release.\nDestructive and dangerous use with caution.")
+	flagset.Usage = func() {
+		fmt.Fprintln(flagset.Output(), takeoffHelp)
+		flagset.PrintDefaults()
+	}
 	CmdRoot.AddCommand(CmdTakeoff)
 }
 
 func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) (*TakeoffParams, error) {
 	flagset := CmdTakeoff.FlagSet
+	takeoffParams.TakeoffParams.Flight = yoke.FlightParams{Input: source}
+	RegisterGlobalFlags(flagset, &takeoffParams.GlobalSettings)
 
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), takeoffHelp)
-		flagset.PrintDefaults()
-	}
-
-	params := TakeoffParams{
-		GlobalSettings: settings,
-		TakeoffParams: yoke.TakeoffParams{
-			Flight: yoke.FlightParams{Input: source},
-		},
-	}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
-
-	flagset.BoolVar(&params.SendToStdout, "stdout", false, "execute the underlying wasm and outputs it to stdout but does not apply any resources to the cluster")
-	flagset.BoolVar(&params.DryRun, "dry", false, "only call the kubernetes api with dry-run; takes precedence over skip-dry-run.")
-	flagset.BoolVar(&params.SkipDryRun, "skip-dry-run", false, "disables running dry run to resources before applying them; ineffective if dry-run is true")
-	flagset.BoolVar(&params.ForceConflicts, "force-conflicts", false, "force apply changes on field manager conflicts")
-	flagset.BoolVar(&params.ForceOwnership, "force-ownership", false, "take ownership of resources during takeoff of resources even if they belong to another release")
-
-	flagset.BoolVar(&params.Lock, "lock", false, "if enabled does locks release before deploying revision (only prevents other locked runs from running).")
-	flagset.BoolVar(&params.CreateNamespace, "create-namespace", false, "create namespace of target release if not present")
-	flagset.BoolVar(&params.CrossNamespace, "cross-namespace", false, "allows releases to create resources in other namespaces than the target namespace")
-	flagset.BoolVar(&params.ClusterAccess.Enabled, "cluster-access", false, "allows flight access to the cluster during takeoff. Only applies when not directing output to stdout or to a local destination.")
-	flagset.BoolVar(&params.Flight.Insecure, "insecure", false, "allows image references to be fetched without TLS (only applies to oci urls)")
-	flagset.Uint64Var(&params.Flight.MaxMemoryMib, "max-memory-mib", 128, "max memory a flight is allowed to allocate at runtime. Max is 4096.")
-	flagset.DurationVar(&params.Flight.Timeout, "timeout", 10*time.Second, "timeout for flight execution. Setting to 0 keeps the default 10 seconds. To remove timeouts completely use a negative duration")
-
-	flagset.BoolVar(&params.DiffOnly, "diff-only", false, "show diff between current revision and would be applied state. Does not apply anything to cluster")
-	flagset.BoolVar(&params.Color, "color", term.IsTerminal(int(os.Stdout.Fd())), "use colored output in diffs")
-	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff (ignored if not using --diff-only)")
-	flagset.StringVar(&params.Out, "out", "", "if present outputs flight resources to directory specified, if out is - outputs to standard out")
-	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
-	flagset.DurationVar(&params.Wait, "wait", 0, "time to wait for release to be ready")
-	flagset.DurationVar(&params.Poll, "poll", 5*time.Second, "interval to poll resource state at. Used with --wait")
-
-	flagset.IntVar(&params.HistoryCapSize, "history-cap", 10, "max number of revisions to keep in release history. 0 or less is unbounded.")
-
-	flagset.StringVar(&params.Flight.CompilationCacheDir, "compilation-cache", "", "location to cache wasm compilations")
-	flagset.StringVar(&params.Checksum, "checksum", "", "sha256 checksum for desired module. If module does not match checksum takeoff will fail. Checksum can be inferred from oci tag or from  http basepath")
-	flagset.StringVar(&params.VerifyKeyPath, "verify", "", "path to public key or directory of keys to verify module signature against.")
-
-	flagset.Func(
-		"resource-access",
-		"allows flights with cluster-access to read resources outside of the release that match pattern. This flag can be set many times and matchers can be comma separated.",
-		func(s string) error {
-			params.ClusterAccess.ResourceMatchers = append(params.ClusterAccess.ResourceMatchers, strings.Split(s, ",")...)
-			return nil
-		},
-	)
-
-	var removeAll bool
-	flagset.BoolVar(&removeAll, "remove-all", false, "enables pruning of crds and namespaces owned by the release if a new revision would orphan them.\nDestructive and dangerous use with caution.")
-	flagset.BoolVar(&params.RemoveCRDs, "remove-crds", false, "enables pruning of crds owned by the release.\nDestructive and dangerous use with caution.")
-	flagset.BoolVar(&params.RemoveNamespaces, "remove-namespaces", false, "enables pruning of namespaces owned by the release.\nDestructive and dangerous use with caution.")
-
-	args, params.Flight.Args = internal.CutArgs(args)
+	args, takeoffParams.Flight.Args = internal.CutArgs(args)
 
 	flagset.Parse(args)
 
-	if removeAll {
-		params.RemoveCRDs = true
-		params.RemoveNamespaces = true
+	if takeoffRemoveAll {
+		takeoffParams.RemoveCRDs = true
+		takeoffParams.RemoveNamespaces = true
 	}
 
-	params.Release = flagset.Arg(0)
-	params.Flight.Path = flagset.Arg(1)
+	takeoffParams.Release = flagset.Arg(0)
+	takeoffParams.Flight.Path = flagset.Arg(1)
 
-	if params.Release == "" {
+	if takeoffParams.Release == "" {
 		return nil, fmt.Errorf("release is required as first positional arg")
 	}
-	if params.Flight.Input == nil && params.Flight.Path == "" {
+	if takeoffParams.Flight.Input == nil && takeoffParams.Flight.Path == "" {
 		return nil, fmt.Errorf("flight-path is required as second position arg")
 	}
 
-	return &params, nil
+	return &takeoffParams, nil
 }
 
 func TakeOff(ctx context.Context, params TakeoffParams) error {

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -24,12 +24,19 @@ type TakeoffParams struct {
 //go:embed cmd_takeoff_help.txt
 var takeoffHelp string
 
+var CmdTakeoff = &YokeCommand{
+	Name:     "takeoff",
+	Aliases:  []string{"up", "apply"},
+	FlagsSet: flag.NewFlagSet("takeoff", flag.ExitOnError),
+}
+
 func init() {
 	takeoffHelp = strings.TrimSpace(internal.Colorize(takeoffHelp))
+	CmdRoot.AddCommand(CmdTakeoff)
 }
 
 func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) (*TakeoffParams, error) {
-	flagset := flag.NewFlagSet("takeoff", flag.ExitOnError)
+	flagset := CmdTakeoff.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), takeoffHelp)

--- a/cmd/yoke/cmd_turbulence.go
+++ b/cmd/yoke/cmd_turbulence.go
@@ -23,9 +23,9 @@ type TurbulenceParams struct {
 var turbulenceHelp string
 
 var CmdTurbulence = &YokeCommand{
-	Name:     "turbulence",
-	Aliases:  []string{"drift", "diff"},
-	FlagsSet: flag.NewFlagSet("turbulence", flag.ExitOnError),
+	Name:    "turbulence",
+	Aliases: []string{"drift", "diff"},
+	FlagSet: flag.NewFlagSet("turbulence", flag.ExitOnError),
 }
 
 func init() {
@@ -34,7 +34,7 @@ func init() {
 }
 
 func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulenceParams, error) {
-	flagset := CmdTurbulence.FlagsSet
+	flagset := CmdTurbulence.FlagSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), turbulenceHelp)

--- a/cmd/yoke/cmd_turbulence.go
+++ b/cmd/yoke/cmd_turbulence.go
@@ -22,12 +22,19 @@ type TurbulenceParams struct {
 //go:embed cmd_turbulence_help.txt
 var turbulenceHelp string
 
+var CmdTurbulence = &YokeCommand{
+	Name:     "turbulence",
+	Aliases:  []string{"drift", "diff"},
+	FlagsSet: flag.NewFlagSet("turbulence", flag.ExitOnError),
+}
+
 func init() {
 	turbulenceHelp = strings.TrimSpace(internal.Colorize(turbulenceHelp))
+	CmdRoot.AddCommand(CmdTurbulence)
 }
 
 func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulenceParams, error) {
-	flagset := flag.NewFlagSet("turbulence", flag.ExitOnError)
+	flagset := CmdTurbulence.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), turbulenceHelp)

--- a/cmd/yoke/cmd_turbulence.go
+++ b/cmd/yoke/cmd_turbulence.go
@@ -27,27 +27,14 @@ var CmdTurbulence = &YokeCommand{
 	Aliases: []string{"drift", "diff"},
 	FlagSet: flag.NewFlagSet("turbulence", flag.ExitOnError),
 }
+var turbulencParams TurbulenceParams
 
 func init() {
 	turbulenceHelp = strings.TrimSpace(internal.Colorize(turbulenceHelp))
-	CmdRoot.AddCommand(CmdTurbulence)
-}
-
-func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulenceParams, error) {
 	flagset := CmdTurbulence.FlagSet
-
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), turbulenceHelp)
-		flagset.PrintDefaults()
-	}
-
-	params := TurbulenceParams{GlobalSettings: settings}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
-
-	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff")
+	flagset.IntVar(&turbulencParams.Context, "context", 4, "number of lines of context in diff")
 	flagset.BoolVar(
-		&params.ConflictsOnly,
+		&turbulencParams.ConflictsOnly,
 		"conflict-only",
 		true,
 		""+
@@ -55,20 +42,33 @@ func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulencePar
 			"If false, will show diff against state that was not declared;\n"+
 			"such as server generated annotations, status, defaults and more",
 	)
-	flagset.BoolVar(&params.Fix, "fix", false, "fix the drift. If present conflict-only will be true.")
-	flagset.BoolVar(&params.Color, "color", term.IsTerminal(int(os.Stdout.Fd())), "outputs diff with color")
-	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
+	flagset.BoolVar(&turbulencParams.Fix, "fix", false, "fix the drift. If present conflict-only will be true.")
+	flagset.BoolVar(&turbulencParams.Color, "color", term.IsTerminal(int(os.Stdout.Fd())), "outputs diff with color")
+	flagset.StringVar(&turbulencParams.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
+
+	flagset.Usage = func() {
+		fmt.Fprintln(flagset.Output(), turbulenceHelp)
+		flagset.PrintDefaults()
+	}
+	CmdRoot.AddCommand(CmdTurbulence)
+}
+
+func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulenceParams, error) {
+	flagset := CmdTurbulence.FlagSet
+
+	turbulencParams.GlobalSettings = settings
+	RegisterGlobalFlags(flagset, &turbulencParams.GlobalSettings)
 
 	flagset.Parse(args)
 
-	params.Release = flagset.Arg(0)
-	if params.Release == "" {
+	turbulencParams.Release = flagset.Arg(0)
+	if turbulencParams.Release == "" {
 		return nil, fmt.Errorf("release is required")
 	}
 
-	params.ConflictsOnly = params.ConflictsOnly || params.Fix
+	turbulencParams.ConflictsOnly = turbulencParams.ConflictsOnly || turbulencParams.Fix
 
-	return &params, nil
+	return &turbulencParams, nil
 }
 
 func Turbulence(ctx context.Context, params TurbulenceParams) error {

--- a/cmd/yoke/cmd_turbulence.go
+++ b/cmd/yoke/cmd_turbulence.go
@@ -22,21 +22,9 @@ type TurbulenceParams struct {
 //go:embed cmd_turbulence_help.txt
 var turbulenceHelp string
 
-func init() {
-	turbulenceHelp = strings.TrimSpace(internal.Colorize(turbulenceHelp))
-}
-
-func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulenceParams, error) {
+var CmdTurbulence = NewCommand("turbulence", []string{"drift", "diff"}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
 	flagset := flag.NewFlagSet("turbulence", flag.ExitOnError)
-
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), turbulenceHelp)
-		flagset.PrintDefaults()
-	}
-
-	params := TurbulenceParams{GlobalSettings: settings}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
+	params := TurbulenceParams{}
 
 	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff")
 	flagset.BoolVar(
@@ -52,17 +40,27 @@ func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulencePar
 	flagset.BoolVar(&params.Color, "color", term.IsTerminal(int(os.Stdout.Fd())), "outputs diff with color")
 	flagset.StringVar(&params.Namespace, "namespace", "", "release target namespace, defaults to context namespace if not provided")
 
-	flagset.Parse(args)
-
-	params.Release = flagset.Arg(0)
-	if params.Release == "" {
-		return nil, fmt.Errorf("release is required")
+	flagset.Usage = func() {
+		turbulenceHelp = strings.TrimSpace(internal.Colorize(turbulenceHelp))
+		fmt.Fprintln(flagset.Output(), turbulenceHelp)
+		flagset.PrintDefaults()
 	}
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
 
-	params.ConflictsOnly = params.ConflictsOnly || params.Fix
+		params.GlobalSettings = settings
+		RegisterGlobalFlags(flagset, &params.GlobalSettings)
 
-	return &params, nil
-}
+		flagset.Parse(args)
+
+		params.Release = flagset.Arg(0)
+		if params.Release == "" {
+			return fmt.Errorf("release is required")
+		}
+
+		params.ConflictsOnly = params.ConflictsOnly || params.Fix
+		return Turbulence(ctx, params)
+	}
+})
 
 func Turbulence(ctx context.Context, params TurbulenceParams) error {
 	commander, err := yoke.FromKubeConfigFlags(params.Kube)

--- a/cmd/yoke/cmd_unlatch.go
+++ b/cmd/yoke/cmd_unlatch.go
@@ -25,33 +25,35 @@ var CmdUnlatch = &YokeCommand{
 	FlagSet: flag.NewFlagSet("unlatch", flag.ExitOnError),
 }
 
+var unlatchParams UnlatchParams
+
 func init() {
 	maydayHelp = strings.TrimSpace(internal.Colorize(unlatchHelp))
-	CmdRoot.AddCommand(CmdUnlatch)
-}
-
-func GetUnlatchParams(settings GlobalSettings, args []string) (*UnlatchParams, error) {
 	flagset := CmdUnlatch.FlagSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), maydayHelp)
 		flagset.PrintDefaults()
 	}
+	flagset.StringVar(&unlatchParams.Namespace, "namespace", "default", "target namespace of release to remove")
+	CmdRoot.AddCommand(CmdUnlatch)
+}
 
-	params := UnlatchParams{GlobalSettings: settings}
+func GetUnlatchParams(settings GlobalSettings, args []string) (*UnlatchParams, error) {
+	flagset := CmdUnlatch.FlagSet
 
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
+	unlatchParams.GlobalSettings = settings
 
-	flagset.StringVar(&params.Namespace, "namespace", "default", "target namespace of release to remove")
+	RegisterGlobalFlags(flagset, &unlatchParams.GlobalSettings)
 
 	flagset.Parse(args)
 
-	params.Release = flagset.Arg(0)
-	if params.Release == "" {
+	unlatchParams.Release = flagset.Arg(0)
+	if unlatchParams.Release == "" {
 		return nil, fmt.Errorf("release is required")
 	}
 
-	return &params, nil
+	return &unlatchParams, nil
 }
 
 func Unlatch(ctx context.Context, params UnlatchParams) error {

--- a/cmd/yoke/cmd_unlatch.go
+++ b/cmd/yoke/cmd_unlatch.go
@@ -20,9 +20,9 @@ type UnlatchParams struct {
 var unlatchHelp string
 
 var CmdUnlatch = &YokeCommand{
-	Name:     "unlatch",
-	Aliases:  []string{"unlock"},
-	FlagsSet: flag.NewFlagSet("unlatch", flag.ExitOnError),
+	Name:    "unlatch",
+	Aliases: []string{"unlock"},
+	FlagSet: flag.NewFlagSet("unlatch", flag.ExitOnError),
 }
 
 func init() {
@@ -31,7 +31,7 @@ func init() {
 }
 
 func GetUnlatchParams(settings GlobalSettings, args []string) (*UnlatchParams, error) {
-	flagset := CmdUnlatch.FlagsSet
+	flagset := CmdUnlatch.FlagSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), maydayHelp)

--- a/cmd/yoke/cmd_unlatch.go
+++ b/cmd/yoke/cmd_unlatch.go
@@ -19,12 +19,19 @@ type UnlatchParams struct {
 //go:embed cmd_unlatch_help.txt
 var unlatchHelp string
 
+var CmdUnlatch = &YokeCommand{
+	Name:     "unlatch",
+	Aliases:  []string{"unlock"},
+	FlagsSet: flag.NewFlagSet("unlatch", flag.ExitOnError),
+}
+
 func init() {
 	maydayHelp = strings.TrimSpace(internal.Colorize(unlatchHelp))
+	CmdRoot.AddCommand(CmdUnlatch)
 }
 
 func GetUnlatchParams(settings GlobalSettings, args []string) (*UnlatchParams, error) {
-	flagset := flag.NewFlagSet("unlatch", flag.ExitOnError)
+	flagset := CmdUnlatch.FlagsSet
 
 	flagset.Usage = func() {
 		fmt.Fprintln(flagset.Output(), maydayHelp)

--- a/cmd/yoke/cmd_unlatch.go
+++ b/cmd/yoke/cmd_unlatch.go
@@ -19,38 +19,30 @@ type UnlatchParams struct {
 //go:embed cmd_unlatch_help.txt
 var unlatchHelp string
 
-func init() {
-	maydayHelp = strings.TrimSpace(internal.Colorize(unlatchHelp))
-}
-
-func GetUnlatchParams(settings GlobalSettings, args []string) (*UnlatchParams, error) {
+var CmdUnlatch = NewCommand("unlatch", []string{"unlock"}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
 	flagset := flag.NewFlagSet("unlatch", flag.ExitOnError)
+	params := UnlatchParams{}
 
 	flagset.Usage = func() {
+		maydayHelp = strings.TrimSpace(internal.Colorize(unlatchHelp))
 		fmt.Fprintln(flagset.Output(), maydayHelp)
 		flagset.PrintDefaults()
 	}
-
-	params := UnlatchParams{GlobalSettings: settings}
-
-	RegisterGlobalFlags(flagset, &params.GlobalSettings)
-
 	flagset.StringVar(&params.Namespace, "namespace", "default", "target namespace of release to remove")
 
-	flagset.Parse(args)
-
-	params.Release = flagset.Arg(0)
-	if params.Release == "" {
-		return nil, fmt.Errorf("release is required")
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
+		params.GlobalSettings = settings
+		RegisterGlobalFlags(flagset, &params.GlobalSettings)
+		flagset.Parse(args)
+		params.Release = flagset.Arg(0)
+		params.Release = flagset.Arg(0)
+		if params.Release == "" {
+			return fmt.Errorf("release is required")
+		}
+		commander, err := yoke.FromKubeConfigFlags(params.Kube)
+		if err != nil {
+			return err
+		}
+		return commander.UnlockRelease(ctx, params.UnlockParams)
 	}
-
-	return &params, nil
-}
-
-func Unlatch(ctx context.Context, params UnlatchParams) error {
-	commander, err := yoke.FromKubeConfigFlags(params.Kube)
-	if err != nil {
-		return err
-	}
-	return commander.UnlockRelease(ctx, params.UnlockParams)
-}
+})

--- a/cmd/yoke/cmd_verify.go
+++ b/cmd/yoke/cmd_verify.go
@@ -14,8 +14,8 @@ import (
 var verifyHelp string
 
 var CmdVerify = &YokeCommand{
-	Name:     "verify",
-	FlagsSet: flag.NewFlagSet("verify", flag.ExitOnError),
+	Name:    "verify",
+	FlagSet: flag.NewFlagSet("verify", flag.ExitOnError),
 }
 
 func init() {

--- a/cmd/yoke/cmd_verify.go
+++ b/cmd/yoke/cmd_verify.go
@@ -13,8 +13,14 @@ import (
 //go:embed cmd_verify_help.txt
 var verifyHelp string
 
+var CmdVerify = &YokeCommand{
+	Name:     "verify",
+	FlagsSet: flag.NewFlagSet("verify", flag.ExitOnError),
+}
+
 func init() {
 	verifyHelp = strings.TrimSpace(internal.Colorize(verifyHelp))
+	CmdRoot.AddCommand(CmdVerify)
 }
 
 func GetVerifyParams(args []string) (*yoke.VerifyParams, error) {

--- a/cmd/yoke/cmd_verify.go
+++ b/cmd/yoke/cmd_verify.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	_ "embed"
 	"flag"
 	"fmt"
@@ -13,31 +14,27 @@ import (
 //go:embed cmd_verify_help.txt
 var verifyHelp string
 
-func init() {
-	verifyHelp = strings.TrimSpace(internal.Colorize(verifyHelp))
-}
-
-func GetVerifyParams(args []string) (*yoke.VerifyParams, error) {
+var CmdVerify = NewCommand("verify", []string{}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
 	flagset := flag.NewFlagSet("verify", flag.ExitOnError)
-
+	params := yoke.VerifyParams{}
 	flagset.Usage = func() {
+		verifyHelp = strings.TrimSpace(internal.Colorize(verifyHelp))
 		fmt.Fprintln(flagset.Output(), verifyHelp)
 		flagset.PrintDefaults()
 	}
-
-	var params yoke.VerifyParams
 	flagset.StringVar(&params.KeyPath, "key", "", "Path to pulbic key pem used for verifying")
+	return flagset, func(ctx context.Context, settings GlobalSettings, args []string) error {
+		flagset.Parse(args)
 
-	flagset.Parse(args)
+		params.WasmFile = flagset.Arg(0)
 
-	params.WasmFile = flagset.Arg(0)
+		if params.WasmFile == "" {
+			return fmt.Errorf("wasm file must be specified as first argument")
+		}
+		if params.KeyPath == "" {
+			return fmt.Errorf("key is required")
+		}
 
-	if params.WasmFile == "" {
-		return nil, fmt.Errorf("wasm file must be specified as first argument")
+		return yoke.Verify(params)
 	}
-	if params.KeyPath == "" {
-		return nil, fmt.Errorf("key is required")
-	}
-
-	return &params, nil
-}
+})

--- a/cmd/yoke/cmd_verify.go
+++ b/cmd/yoke/cmd_verify.go
@@ -18,32 +18,34 @@ var CmdVerify = &YokeCommand{
 	FlagSet: flag.NewFlagSet("verify", flag.ExitOnError),
 }
 
+var verifyParams yoke.VerifyParams
+
 func init() {
 	verifyHelp = strings.TrimSpace(internal.Colorize(verifyHelp))
+
+	flagset := flag.NewFlagSet("verify", flag.ExitOnError)
+	flagset.Usage = func() {
+		fmt.Fprintln(flagset.Output(), verifyHelp)
+		flagset.PrintDefaults()
+	}
+
+	flagset.StringVar(&verifyParams.KeyPath, "key", "", "Path to pulbic key pem used for verifying")
 	CmdRoot.AddCommand(CmdVerify)
 }
 
 func GetVerifyParams(args []string) (*yoke.VerifyParams, error) {
 	flagset := flag.NewFlagSet("verify", flag.ExitOnError)
 
-	flagset.Usage = func() {
-		fmt.Fprintln(flagset.Output(), verifyHelp)
-		flagset.PrintDefaults()
-	}
-
-	var params yoke.VerifyParams
-	flagset.StringVar(&params.KeyPath, "key", "", "Path to pulbic key pem used for verifying")
-
 	flagset.Parse(args)
 
-	params.WasmFile = flagset.Arg(0)
+	verifyParams.WasmFile = flagset.Arg(0)
 
-	if params.WasmFile == "" {
+	if verifyParams.WasmFile == "" {
 		return nil, fmt.Errorf("wasm file must be specified as first argument")
 	}
-	if params.KeyPath == "" {
+	if verifyParams.KeyPath == "" {
 		return nil, fmt.Errorf("key is required")
 	}
 
-	return &params, nil
+	return &verifyParams, nil
 }

--- a/cmd/yoke/cmd_version.go
+++ b/cmd/yoke/cmd_version.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"runtime/debug"
 
@@ -9,6 +10,12 @@ import (
 
 	"github.com/yokecd/yoke/internal"
 )
+
+var CmdVersion = NewCommand("version", []string{}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
+	return flag.NewFlagSet("version", flag.ExitOnError), func(ctx context.Context, settings GlobalSettings, args []string) error {
+		return Version(ctx)
+	}
+})
 
 func Version(ctx context.Context) error {
 	tbl := table.NewWriter()

--- a/cmd/yoke/cmd_version.go
+++ b/cmd/yoke/cmd_version.go
@@ -10,6 +10,14 @@ import (
 	"github.com/yokecd/yoke/internal"
 )
 
+var CmdVersion = &YokeCommand{
+	Name: "version",
+}
+
+func init() {
+	CmdRoot.AddCommand(CmdVersion)
+}
+
 func Version(ctx context.Context) error {
 	tbl := table.NewWriter()
 	tbl.SetStyle(table.StyleRounded)

--- a/cmd/yoke/command.go
+++ b/cmd/yoke/command.go
@@ -17,10 +17,12 @@ type YokeCommand struct {
 	FlagSet        *flag.FlagSet
 	SubCommands    []*YokeCommand
 	CompletionFunc func([]string)
+	Parent         *YokeCommand
 }
 
 // We might actually want to implement this as a map to make it blazingly fast
 func (y *YokeCommand) AddCommand(sub *YokeCommand) {
+	sub.Parent = y
 	y.SubCommands = append(y.SubCommands, sub)
 }
 

--- a/cmd/yoke/command.go
+++ b/cmd/yoke/command.go
@@ -14,7 +14,7 @@ type YokeCommandRunner interface {
 type YokeCommand struct {
 	Name           string
 	Aliases        []string
-	FlagsSet       *flag.FlagSet
+	FlagSet        *flag.FlagSet
 	SubCommands    []*YokeCommand
 	CompletionFunc func([]string)
 }

--- a/cmd/yoke/command.go
+++ b/cmd/yoke/command.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"flag"
+)
+
+type YokeCommandRunner interface {
+	Run(ctx context.Context, settings GlobalSettings, subCommands string) error
+}
+
+// The YokeCommand struct represents a cli commmand
+// It should have a name, alias, and subcommands
+type YokeCommand struct {
+	Name           string
+	Aliases        []string
+	FlagsSet       *flag.FlagSet
+	SubCommands    []*YokeCommand
+	CompletionFunc func([]string)
+}
+
+// We might actually want to implement this as a map to make it blazingly fast
+func (y *YokeCommand) AddCommand(sub *YokeCommand) {
+	y.SubCommands = append(y.SubCommands, sub)
+}
+
+func (y YokeCommand) AllNames() []string {
+	return append(y.Aliases, y.Name)
+}

--- a/cmd/yoke/command.go
+++ b/cmd/yoke/command.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"flag"
+)
+
+type YokeCommandRunner interface {
+	Run(ctx context.Context, settings GlobalSettings, subCommands string) error
+}
+
+// The YokeCommand struct represents a cli commmand
+// It should have a name, alias, and subcommands
+type YokeCommand struct {
+	Name           string
+	Aliases        []string
+	FlagSet        *flag.FlagSet
+	SubCommands    map[string]*YokeCommand
+	CompletionFunc func([]string)
+	Parent         *YokeCommand
+	Runner         CmdRunner
+}
+
+// AddCommand registers sub into the parents SubCommands
+func (y *YokeCommand) AddCommand(sub *YokeCommand) {
+	sub.Parent = y
+	y.SubCommands[sub.Name] = sub
+	for _, alias := range sub.Aliases {
+		_, alreadyThere := y.SubCommands[alias]
+		if !alreadyThere {
+			y.SubCommands[alias] = sub
+		}
+	}
+}
+
+// AllNames returns the name of a command and all of its aliases
+func (y YokeCommand) AllNames() []string {
+	return append(y.Aliases, y.Name)
+}
+
+type CmdRunner func(ctx context.Context, settings GlobalSettings, args []string) error
+type CmdBuilder func(ctx context.Context) (*flag.FlagSet, CmdRunner)
+
+func NewCommand(name string, aliases []string, builder CmdBuilder) *YokeCommand {
+	flagset, runner := builder(context.Background())
+	return &YokeCommand{
+		Name:        name,
+		Aliases:     aliases,
+		FlagSet:     flagset,
+		Runner:      runner,
+		SubCommands: make(map[string]*YokeCommand),
+	}
+}
+
+// Seek returns the YokeCommand and the commands after the found command
+// for a given set of args
+func Seek(args []string) (*YokeCommand, []string) {
+	cmdPtr := CmdRoot
+	var argsOut = args
+	for i, arg := range args {
+		nextCmd, ok := cmdPtr.SubCommands[arg]
+		if ok {
+			cmdPtr = nextCmd
+			if i+1 < len(args) {
+				argsOut = args[i+1:]
+			} else {
+				argsOut = []string{}
+			}
+		}
+	}
+	if cmdPtr == CmdRoot {
+		if len(args) > 0 {
+			argsOut = args[1:]
+		}
+	}
+	return cmdPtr, argsOut
+}

--- a/cmd/yoke/command_test.go
+++ b/cmd/yoke/command_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestCmdSubs asserts that all of the expected sub commands are in place
+func TestCmdSubs(t *testing.T) {
+	validCommands := []string{
+		"apply", "atc", "blackbox",
+		"delete", "descent", "diff",
+		"down", "drift", "inspect",
+		"mayday", "meta", "push",
+		"restore", "schematics", "sign",
+		"stow", "takeoff", "turbulence",
+		"unlatch", "unlock", "up",
+		"verify", "version",
+	}
+	for _, cmd := range validCommands {
+		if _, ok := CmdRoot.SubCommands[cmd]; !ok {
+			t.Fatalf("expected %s to be a subcommand of the root command", cmd)
+		}
+	}
+	for _, cmd := range []string{"ls", "set", "get"} {
+		if _, ok := CmdSchematics.SubCommands[cmd]; !ok {
+			t.Fatalf("expected %s to be a subcommand of the schematics command", cmd)
+		}
+	}
+}
+
+// TestCmdSeekRunner tests that the Seek function can find the correct
+// sub command runner given a slice of args
+func TestCmdSeekRunner(t *testing.T) {
+	type tMatrix struct {
+		Want CmdRunner
+		Args []string
+	}
+	tests := []tMatrix{
+		{Want: CmdRoot.Runner, Args: []string{"yoke"}},
+		{Want: CmdSchematicsGet.Runner, Args: []string{"yoke", "schematics", "get"}},
+		{Want: CmdSchematicsLs.Runner, Args: []string{"yoke", "schematics", "ls"}},
+		{Want: CmdSchematicsSet.Runner, Args: []string{"yoke", "schematics", "set"}},
+	}
+	for k, c := range CmdRoot.SubCommands {
+		tests = append(tests, tMatrix{
+			Want: c.Runner,
+			Args: []string{"yoke", k},
+		})
+	}
+	for _, s := range tests {
+		cmd, _ := Seek(s.Args)
+		if reflect.ValueOf(cmd.Runner) != reflect.ValueOf(s.Want) {
+			t.Fatalf("got function mismatch for %v", s.Args)
+		}
+	}
+}
+
+func TestCmdSeekExtraArgs(t *testing.T) {
+	type tMatrix struct {
+		Want CmdRunner
+		Args []string
+	}
+	tests := []tMatrix{
+		{Want: CmdRoot.Runner, Args: []string{"yoke", "--debug", "foo"}},
+		{Want: CmdSchematicsGet.Runner, Args: []string{"yoke", "schematics", "get", "--debug", "foo"}},
+		{Want: CmdSchematicsLs.Runner, Args: []string{"yoke", "schematics", "ls", "--debug", "foo"}},
+		{Want: CmdSchematicsSet.Runner, Args: []string{"yoke", "schematics", "set", "--debug", "foo"}},
+	}
+	for k, c := range CmdRoot.SubCommands {
+		tests = append(tests, tMatrix{
+			Want: c.Runner,
+			Args: []string{"yoke", k, "--debug", "foo"},
+		})
+	}
+	for _, s := range tests {
+		_, args := Seek(s.Args)
+		if !isSubset(args, []string{"--debug", "foo"}) || !(len(args) == 2) {
+			t.Fatalf("got args mismatch for %v, got: %v", s.Args, args)
+		}
+	}
+	if _, args := Seek([]string{"yoke"}); len(args) != 0 {
+		t.Fatalf("expected root command to have zero args after it")
+	}
+}

--- a/cmd/yoke/command_test.go
+++ b/cmd/yoke/command_test.go
@@ -1,0 +1,8 @@
+package main
+
+import "testing"
+
+func TestCommandRoot(t *testing.T) {
+	t.Logf("TODO")
+}
+

--- a/cmd/yoke/complete.go
+++ b/cmd/yoke/complete.go
@@ -9,7 +9,9 @@ import (
 )
 
 var validCommands = map[string]*YokeCommand{
-	"atc": CmdATC,
+	// fake alias to the root command
+	"complete": CmdRoot,
+	"atc":      CmdATC,
 	"takeoff": {
 		Name:    "takeoff",
 		Aliases: []string{"up", "apply"},
@@ -57,21 +59,14 @@ func cleanArg(argIn string) string {
 	return argIn
 }
 
-func CmdCompletion() {
-	root := CmdRoot
-	for _, cmd := range root.SubCommands {
-		fmt.Println(cmd.Name)
-	}
-}
-
-func FlagCompletion(cmd YokeCommand, args []string) {
-	// TODO: aliases
-	i := slices.Index(args, cmd.Name)
-	if i == -1 {
+func FlagCompletion(args []string, cmd *YokeCommand) {
+	partial := args[len(args)-1]
+	// TODO: iterate through sub commands
+	if cmd.FlagsSet == nil {
+		fmt.Println("DEBUG: flagset null")
 		return
 	}
-	rest := args[i:]
-	partial := rest[len(rest)-1]
+	fmt.Println("DEBUG: flag:", cmd.FlagsSet.Usage)
 	cmd.FlagsSet.VisitAll(func(f *flag.Flag) {
 		if partial == "" || strings.HasPrefix(f.Name, partial) {
 			// could optimize with hash map
@@ -82,32 +77,48 @@ func FlagCompletion(cmd YokeCommand, args []string) {
 	})
 }
 
+func commandsWithPrefix(argsMap map[string]bool, partial string) []string {
+	out := make([]string, 0)
+	for _, cmd := range CmdRoot.SubCommands {
+		// FIXME we should just pass in args,
+		_, ok := argsMap[cleanArg(cmd.Name)]
+		if !ok {
+			// TODO: also aliases
+			if strings.HasPrefix(cmd.Name, partial) {
+				out = append(out, cmd.Name)
+			}
+		}
+	}
+	return out
+}
+
 func Complete() {
 	if len(os.Args) < 2 {
 	}
 	currentArgs := make(map[string]bool)
 	for _, arg := range os.Args {
-		currentArgs[cleanArg(arg)] = true
+		currentArgs[arg] = true
 	}
 	partial := os.Args[len(os.Args)-1]
-	fmt.Println("DEBUG: ", partial)
-	fmt.Println("DEBUG: ", currentArgs)
-	// partial was a full command, we should hop into a sub command completion
-	lastCmd, ok := validCommands[partial]
-	if ok {
-		// looking for the next command now
-		fmt.Printf("DEBUG: cleaned %s -> ''\n", partial)
-		FlagCompletion(*lastCmd, os.Args)
-	}
-	// is it in a top level command
-	for _, cmd := range CmdRoot.SubCommands {
-		name := cmd.Name
-		_, ok := currentArgs[cleanArg(name)]
-		if !ok {
-			// TODO: also aliases
-			if strings.HasPrefix(name, partial) {
-				fmt.Println(name)
-			}
+	if strings.HasPrefix(partial, "-") {
+		partialClean := strings.TrimLeft(partial, "-")
+		lastCmdString := ""
+		if len(os.Args) > 2 {
+			lastCmdString = os.Args[len(os.Args)-2]
 		}
+		fmt.Println("DEBUG: partial", partialClean)
+		fmt.Println("DEBUG: lcs", lastCmdString)
+		// partial was a full command, we should hop into a sub command completion
+		lastCmd, ok := validCommands[lastCmdString]
+		if ok {
+			// looking for the next command now
+			fmt.Printf("DEBUG: completing for %s %s\n", lastCmd.Name, partial)
+			FlagCompletion(os.Args, lastCmd)
+		}
+	}
+	//if it's not a full command, get top-level completions
+	comps := commandsWithPrefix(currentArgs, partial)
+	for _, c := range comps {
+		fmt.Println(c)
 	}
 }

--- a/cmd/yoke/complete.go
+++ b/cmd/yoke/complete.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+var validCommands = map[string]*YokeCommand{
+	"atc": CmdATC,
+	"takeoff": {
+		Name:    "takeoff",
+		Aliases: []string{"up", "apply"},
+	},
+	"descent": {
+		Name:    "descent",
+		Aliases: []string{"down", "restore"},
+	},
+	"mayday": {
+		Name:    "mayday",
+		Aliases: []string{"delete"},
+	},
+	"blackbox": {
+		Name:    "blackbox",
+		Aliases: []string{"inspect"},
+	},
+	"turbulence": {
+		Name:    "turbulence",
+		Aliases: []string{"drift", "diff"},
+	},
+	"stow": {
+		Name:    "stow",
+		Aliases: []string{"push"},
+	},
+	"unlatch": {
+		Name:    "unlatch",
+		Aliases: []string{"unlock"},
+	},
+	"schematics": {
+		Name:    "schematics",
+		Aliases: []string{"meta"},
+	},
+	"sign": {
+		Name: "sign",
+	},
+	"verify": {
+		Name: "verify",
+	},
+	"version": {
+		Name: "version",
+	},
+}
+
+func cleanArg(argIn string) string {
+	return argIn
+}
+
+func CmdCompletion() {
+	root := CmdRoot
+	for _, cmd := range root.SubCommands {
+		fmt.Println(cmd.Name)
+	}
+}
+
+func FlagCompletion(cmd YokeCommand, args []string) {
+	// TODO: aliases
+	i := slices.Index(args, cmd.Name)
+	if i == -1 {
+		return
+	}
+	rest := args[i:]
+	partial := rest[len(rest)-1]
+	cmd.FlagsSet.VisitAll(func(f *flag.Flag) {
+		if partial == "" || strings.HasPrefix(f.Name, partial) {
+			// could optimize with hash map
+			if !slices.Contains(args, f.Name) {
+				fmt.Println("-" + f.Name)
+			}
+		}
+	})
+}
+
+func Complete() {
+	if len(os.Args) < 2 {
+	}
+	currentArgs := make(map[string]bool)
+	for _, arg := range os.Args {
+		currentArgs[cleanArg(arg)] = true
+	}
+	partial := os.Args[len(os.Args)-1]
+	fmt.Println("DEBUG: ", partial)
+	fmt.Println("DEBUG: ", currentArgs)
+	// partial was a full command, we should hop into a sub command completion
+	lastCmd, ok := validCommands[partial]
+	if ok {
+		// looking for the next command now
+		fmt.Printf("DEBUG: cleaned %s -> ''\n", partial)
+		FlagCompletion(*lastCmd, os.Args)
+	}
+	// is it in a top level command
+	for _, cmd := range CmdRoot.SubCommands {
+		name := cmd.Name
+		_, ok := currentArgs[cleanArg(name)]
+		if !ok {
+			// TODO: also aliases
+			if strings.HasPrefix(name, partial) {
+				fmt.Println(name)
+			}
+		}
+	}
+}

--- a/cmd/yoke/complete.go
+++ b/cmd/yoke/complete.go
@@ -10,49 +10,19 @@ import (
 
 var validCommands = map[string]*YokeCommand{
 	// fake alias to the root command
-	"complete": CmdRoot,
-	"atc":      CmdATC,
-	"takeoff": {
-		Name:    "takeoff",
-		Aliases: []string{"up", "apply"},
-	},
-	"descent": {
-		Name:    "descent",
-		Aliases: []string{"down", "restore"},
-	},
-	"mayday": {
-		Name:    "mayday",
-		Aliases: []string{"delete"},
-	},
-	"blackbox": {
-		Name:    "blackbox",
-		Aliases: []string{"inspect"},
-	},
-	"turbulence": {
-		Name:    "turbulence",
-		Aliases: []string{"drift", "diff"},
-	},
-	"stow": {
-		Name:    "stow",
-		Aliases: []string{"push"},
-	},
-	"unlatch": {
-		Name:    "unlatch",
-		Aliases: []string{"unlock"},
-	},
-	"schematics": {
-		Name:    "schematics",
-		Aliases: []string{"meta"},
-	},
-	"sign": {
-		Name: "sign",
-	},
-	"verify": {
-		Name: "verify",
-	},
-	"version": {
-		Name: "version",
-	},
+	"complete":   CmdRoot,
+	"atc":        CmdATC,
+	"takeoff":    CmdTakeoff,
+	"descent":    CmdDescent,
+	"mayday":     CmdMayday,
+	"blackbox":   CmdBlackbox,
+	"turbulence": CmdTurbulence,
+	"stow":       CmdStow,
+	"unlatch":    CmdUnlatch,
+	"schematics": CmdSchematics,
+	"sign":       CmdSign,
+	"verify":     CmdVerify,
+	"version":    CmdVersion,
 }
 
 func cleanArg(argIn string) string {
@@ -60,14 +30,12 @@ func cleanArg(argIn string) string {
 }
 
 func FlagCompletion(args []string, cmd *YokeCommand) {
-	partial := args[len(args)-1]
-	// TODO: iterate through sub commands
-	if cmd.FlagsSet == nil {
+	partial := strings.TrimLeft(args[len(args)-1], "-")
+	if cmd.FlagSet == nil {
 		fmt.Println("DEBUG: flagset null")
 		return
 	}
-	fmt.Println("DEBUG: flag:", cmd.FlagsSet.Usage)
-	cmd.FlagsSet.VisitAll(func(f *flag.Flag) {
+	flag.VisitAll(func(f *flag.Flag) {
 		if partial == "" || strings.HasPrefix(f.Name, partial) {
 			// could optimize with hash map
 			if !slices.Contains(args, f.Name) {

--- a/cmd/yoke/complete.go
+++ b/cmd/yoke/complete.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 )
 
+// TODO: construct from rootcmd's children
 var validCommands = map[string]*YokeCommand{
 	// fake alias to the root command
 	"complete":   CmdRoot,
+	"yoke":       CmdRoot,
 	"atc":        CmdATC,
 	"takeoff":    CmdTakeoff,
 	"descent":    CmdDescent,
@@ -29,35 +31,75 @@ func cleanArg(argIn string) string {
 	return argIn
 }
 
-func FlagCompletion(args []string, cmd *YokeCommand) {
-	partial := strings.TrimLeft(args[len(args)-1], "-")
-	if cmd.FlagSet == nil {
-		fmt.Println("DEBUG: flagset null")
-		return
+func printFlagCompletion(args []string, cmd *YokeCommand) {
+	for _, flag := range getFlagCompletion(args, cmd) {
+		fmt.Println(flag)
 	}
-	flag.VisitAll(func(f *flag.Flag) {
-		if partial == "" || strings.HasPrefix(f.Name, partial) {
-			// could optimize with hash map
-			if !slices.Contains(args, f.Name) {
-				fmt.Println("-" + f.Name)
-			}
-		}
-	})
 }
 
-func commandsWithPrefix(argsMap map[string]bool, partial string) []string {
+// get the flags associated with a yokeCommand
+// it takes all of args slice and the YokeCommand
+func getFlagCompletion(args []string, cmd *YokeCommand) []string {
+	flagSetAll := make(map[string]bool)
 	out := make([]string, 0)
-	for _, cmd := range CmdRoot.SubCommands {
-		// FIXME we should just pass in args,
-		_, ok := argsMap[cleanArg(cmd.Name)]
-		if !ok {
-			// TODO: also aliases
-			if strings.HasPrefix(cmd.Name, partial) {
-				out = append(out, cmd.Name)
+	partial := strings.TrimLeft(args[len(args)-1], "-")
+	if cmd.FlagSet == nil {
+		return out
+	}
+	filterForPrefix := func(f *flag.Flag, p string) {
+		if p == "" || strings.HasPrefix(f.Name, p) {
+			if !slices.Contains(args, f.Name) {
+				flagSetAll["-"+f.Name] = true
 			}
+		}
+	}
+	// Iterate through all of the places we get flags from
+	// If we had more layers, we'd need to not just
+	// FIXME: Actually traverse the tree upward
+	// needs to be upward so that we don't print the wrong flags
+	flag.VisitAll(func(f *flag.Flag) {
+		filterForPrefix(f, partial)
+	})
+	// get flagset flag
+	cmd.FlagSet.VisitAll(func(f *flag.Flag) {
+		filterForPrefix(f, partial)
+	})
+	for k := range flagSetAll {
+		out = append(out, k)
+	}
+	return out
+}
+
+// given the args passed, yield all of the valid next top level cocmmands
+func getCommandCompletions(args []string) []*YokeCommand {
+	out := make([]*YokeCommand, 0)
+	partial := args[len(args)-1]
+	if partial == "complete" || partial == "yoke" {
+		partial = ""
+	}
+	// We've already completed the command
+	cmd, ok := validCommands[partial]
+	if ok {
+		for _, c := range cmd.SubCommands {
+			fmt.Println("\t sub:", c.Name)
+			if strings.HasPrefix(c.Name, partial) || partial == "" {
+				out = append(out, c)
+			}
+		}
+		return out
+	}
+	for k, v := range validCommands {
+		if strings.HasPrefix(k, partial) {
+			out = append(out, v)
 		}
 	}
 	return out
+}
+
+func printCommandCompletions(args []string) {
+	for _, cmd := range getCommandCompletions(args) {
+		fmt.Println(cmd.Name)
+	}
 }
 
 func Complete() {
@@ -69,24 +111,17 @@ func Complete() {
 	}
 	partial := os.Args[len(os.Args)-1]
 	if strings.HasPrefix(partial, "-") {
-		partialClean := strings.TrimLeft(partial, "-")
 		lastCmdString := ""
 		if len(os.Args) > 2 {
 			lastCmdString = os.Args[len(os.Args)-2]
 		}
-		fmt.Println("DEBUG: partial", partialClean)
-		fmt.Println("DEBUG: lcs", lastCmdString)
 		// partial was a full command, we should hop into a sub command completion
 		lastCmd, ok := validCommands[lastCmdString]
 		if ok {
 			// looking for the next command now
-			fmt.Printf("DEBUG: completing for %s %s\n", lastCmd.Name, partial)
-			FlagCompletion(os.Args, lastCmd)
+			printFlagCompletion(os.Args, lastCmd)
 		}
 	}
 	//if it's not a full command, get top-level completions
-	comps := commandsWithPrefix(currentArgs, partial)
-	for _, c := range comps {
-		fmt.Println(c)
-	}
+	printCommandCompletions(os.Args)
 }

--- a/cmd/yoke/complete.go
+++ b/cmd/yoke/complete.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+func cleanArg(argIn string) string {
+	return argIn
+}
+
+func printFlagCompletion(args []string, cmd *YokeCommand) {
+	for _, flag := range getFlagCompletion(args, cmd) {
+		fmt.Println(flag)
+	}
+}
+
+// get the flags associated with a yokeCommand
+// it takes the args slice after the YokeCommand
+func getFlagCompletion(args []string, cmd *YokeCommand) []string {
+	flagSetAll := make(map[string]bool)
+	out := make([]string, 0)
+	partial := strings.TrimLeft(args[len(args)-1], "-")
+	if cmd.FlagSet == nil {
+		return out
+	}
+	appendWithPrefix := func(f *flag.Flag, p string) {
+		if p == "" || strings.HasPrefix(f.Name, p) {
+			if !slices.Contains(args, "-"+f.Name) {
+				flagSetAll["-"+f.Name] = true
+			}
+		}
+	}
+	// Iterate through all of the places we get flags from
+	cur := cmd
+	for cur != nil && cur.FlagSet != nil {
+		cur.FlagSet.VisitAll(func(f *flag.Flag) {
+			appendWithPrefix(f, partial)
+		})
+		cur = cur.Parent
+	}
+
+	for k := range flagSetAll {
+		out = append(out, k)
+	}
+	return out
+}
+
+// given the args passed, yield all of the valid next top level cocmmands
+func getCommandCompletions(args []string, cmd *YokeCommand) []*YokeCommand {
+	out := make([]*YokeCommand, 0)
+	outSet := make(map[string]*YokeCommand)
+	partial := ""
+	if len(args) > 0 {
+		partial = args[len(args)-1]
+	}
+	if partial == "complete" || partial == "yoke" {
+		partial = ""
+	}
+	for _, v := range cmd.SubCommands {
+		if strings.HasPrefix(v.Name, partial) || partial == "" {
+			outSet[v.Name] = v
+		}
+	}
+	for _, cmd := range outSet {
+		out = append(out, cmd)
+	}
+	return out
+}
+
+func printCommandCompletions(args []string, cmd *YokeCommand) {
+	for _, cmd := range getCommandCompletions(args, cmd) {
+		fmt.Println(cmd.Name)
+	}
+}
+
+func Complete() {
+	if len(os.Args) < 2 {
+		return
+	}
+	if _, ok := os.LookupEnv("COMP_LINE"); !ok {
+		fmt.Print(`
+# Please add the following to your bashrc file to enable tab completions
+
+function _yoke() {
+  COMPREPLY=($(yoke complete $COMP_LINE));
+};
+
+complete -F _yoke yoke
+`)
+		return
+	}
+
+	argSet := make(map[string]bool)
+	for _, arg := range os.Args {
+		argSet[arg] = true
+	}
+	argsAfterComp := os.Args[2:]
+	if len(argsAfterComp) > 1 && argsAfterComp[0] == "yoke" {
+		argsAfterComp = argsAfterComp[1:]
+	}
+	cmd, rest := Seek(argsAfterComp)
+	partial := ""
+	if len(rest) > 0 {
+		partial = rest[len(rest)-1]
+	}
+	if strings.HasPrefix(partial, "-") {
+		printFlagCompletion(rest, cmd)
+	}
+	//if it's not a full command, get top-level completions
+	printCommandCompletions(rest, cmd)
+}

--- a/cmd/yoke/complete.go
+++ b/cmd/yoke/complete.go
@@ -83,9 +83,10 @@ func Complete() {
 	}
 	if _, ok := os.LookupEnv("COMP_LINE"); !ok {
 		fmt.Print(`
-# Please add the following to your bashrc file to enable tab completions
+# Please add the following to your bash completion file to enable tab completions
 
 function _yoke() {
+  export COMP_LINE
   COMPREPLY=($(yoke complete $COMP_LINE));
 };
 
@@ -94,15 +95,13 @@ complete -F _yoke yoke
 		return
 	}
 
-	argSet := make(map[string]bool)
-	for _, arg := range os.Args {
-		argSet[arg] = true
+	if len(os.Args) < 2 {
+		return
 	}
-	argsAfterComp := os.Args[2:]
-	if len(argsAfterComp) > 1 && argsAfterComp[0] == "yoke" {
-		argsAfterComp = argsAfterComp[1:]
-	}
-	cmd, rest := Seek(argsAfterComp)
+	// We only want to pass `yoke ...` to Seek,
+	// not `yoke complete yoke ...`
+	argsAfterComplete := os.Args[2:]
+	cmd, rest := Seek(argsAfterComplete)
 	partial := ""
 	if len(rest) > 0 {
 		partial = rest[len(rest)-1]

--- a/cmd/yoke/complete_test.go
+++ b/cmd/yoke/complete_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestDescentFlagCompletions(t *testing.T) {
+	if !slices.Equal(
+		getFlagCompletion(
+			[]string{"yoke", "descent"},
+			validCommands["descent"],
+		), []string{
+			"-debug",
+			"-kube-context",
+			"-namespace",
+			"-poll",
+			"-remove-all",
+			"-remove-crds",
+			"-wait",
+			"-kubeconfig",
+			"-lock",
+			"-remove-namespaces",
+		}) {
+		t.Fatalf("TestDescentFlagCompletions did not yield expected flags")
+	}
+}

--- a/cmd/yoke/complete_test.go
+++ b/cmd/yoke/complete_test.go
@@ -22,6 +22,6 @@ func TestFlagCompletionsDescent(t *testing.T) {
 			"-lock",
 			"-remove-namespaces",
 		}) {
-		t.Fatalf("TestDescentFlagCompletions did not yield expected flags")
+		t.Fatal("TestDescentFlagCompletions did not yield expected flags")
 	}
 }

--- a/cmd/yoke/complete_test.go
+++ b/cmd/yoke/complete_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestDescentFlagCompletions(t *testing.T) {
+func TestFlagCompletionsDescent(t *testing.T) {
 	if !slices.Equal(
 		getFlagCompletion(
 			[]string{"yoke", "descent"},

--- a/cmd/yoke/complete_test.go
+++ b/cmd/yoke/complete_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+// returns true if a is a subset of b
+func isSubset(a, b []string) bool {
+	set := make(map[string]bool)
+	for _, s := range b {
+		set[s] = true
+	}
+	for _, s := range a {
+		_, ok := set[s]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCompFlags(t *testing.T) {
+	t.Setenv("COMP_LINE", "")
+	for _, comp := range []struct {
+		Command *YokeCommand
+		Args    []string
+		Wanted  []string
+	}{
+		{
+			Command: CmdATC,
+			Args:    []string{"-"},
+			Wanted: []string{
+				"-debug-file",
+			},
+		},
+		{
+			Command: CmdBlackbox,
+			Args:    []string{"-"},
+			Wanted: []string{
+				"-context",
+				"-namespace",
+			},
+		},
+		{
+			Command: CmdDescent,
+			Args:    []string{"-"},
+			Wanted: []string{
+				"-lock",
+				"-namespace",
+				"-poll",
+				"-remove-all",
+				"-remove-crds",
+				"-remove-namespaces",
+				"-wait",
+			},
+		},
+		{
+			Command: CmdMayday,
+			Args:    []string{"-"},
+			Wanted: []string{
+				"-namespace",
+				"-remove-all",
+				"-remove-crds",
+				"-remove-namespaces",
+			},
+		},
+		{
+			Command: CmdSchematics,
+			Args:    []string{"-"},
+			Wanted:  []string{"-wasm"},
+		},
+		{
+			Command: CmdSign,
+			Args:    []string{"-"},
+			Wanted: []string{
+				"-key",
+				"-o",
+				"-f",
+			},
+		},
+		{
+			Command: CmdStow,
+			Args:    []string{"-"},
+			Wanted: []string{
+				"-insecure",
+				"-tag",
+			},
+		},
+		{
+			Command: CmdTakeoff,
+			Args:    []string{"-"},
+			Wanted: []string{
+				"-checksum",
+				"-color",
+				"-context",
+				"-cross-namespace",
+				"-diff-only",
+				"-dry",
+				"-insecure",
+				"-remove-crds",
+				"-cluster-access",
+				"-out",
+				"-remove-namespaces",
+				"-timeout",
+				"-verify",
+				"-wait",
+				"-create-namespace",
+				"-force-conflicts",
+				"-history-cap",
+				"-poll",
+				"-resource-access",
+				"-stdout",
+				"-compilation-cache",
+				"-force-ownership",
+				"-lock",
+				"-max-memory-mib",
+				"-namespace",
+				"-remove-all",
+				"-skip-dry-run",
+			},
+		},
+		{
+			Command: CmdTurbulence,
+			Args:    []string{"-"},
+			Wanted: []string{
+				"-conflict-only",
+				"-context",
+				"-fix",
+				"-namespace",
+				"-color",
+			},
+		},
+		{
+			Command: CmdUnlatch,
+			Args:    []string{"-"},
+			Wanted:  []string{"-namespace"},
+		},
+		{
+			Command: CmdVerify,
+			Args:    []string{"-"},
+			Wanted:  []string{"-key"},
+		},
+	} {
+		compLine := getFlagCompletion(comp.Args, comp.Command)
+		// We can't do a full compare here because 'go test' introduces its own flag sets
+		if !isSubset(comp.Wanted, compLine) {
+			t.Fatalf("%s did not yield expected flags, got: %s args: %s", comp.Command.Name, compLine, comp.Args)
+		}
+	}
+}
+
+func TestCompFlagDuplicates(t *testing.T) {
+	t.Setenv("COMP_LINE", "")
+	for _, comp := range []struct {
+		Comp      []string
+		Command   *YokeCommand
+		Args      []string
+		NotInComp []string
+	}{
+		{
+			Args:      []string{"-context", "-"},
+			Command:   CmdBlackbox,
+			NotInComp: []string{"-context"},
+		},
+		{
+			Args:      []string{"-context", "-namespace"},
+			Command:   CmdBlackbox,
+			NotInComp: []string{"-context", "-namespace"},
+		},
+	} {
+		compLine := getFlagCompletion(comp.Args, comp.Command)
+		for _, unwanted := range comp.NotInComp {
+			if slices.Contains(compLine, unwanted) {
+				t.Fatalf("got unexpected flag completion for %s with args %v: got %v", comp.Command.Name, comp.Args, compLine)
+			}
+		}
+	}
+}

--- a/cmd/yoke/complete_test.go
+++ b/cmd/yoke/complete_test.go
@@ -1,16 +1,19 @@
 package main
 
 import (
+	"os"
 	"slices"
 	"testing"
 )
 
 func TestFlagCompletionsDescent(t *testing.T) {
-	if !slices.Equal(
+	comps :=
 		getFlagCompletion(
-			[]string{"yoke", "descent"},
+			[]string{"yoke", "descent", "-"},
 			validCommands["descent"],
-		), []string{
+		)
+	if !slices.Equal(
+		comps, []string{
 			"-debug",
 			"-kube-context",
 			"-namespace",
@@ -22,6 +25,6 @@ func TestFlagCompletionsDescent(t *testing.T) {
 			"-lock",
 			"-remove-namespaces",
 		}) {
-		t.Fatal("TestDescentFlagCompletions did not yield expected flags")
+		t.Fatal("TestDescentFlagCompletions did not yield expected flags, got: ", comps, "ARGS: ", os.Args)
 	}
 }

--- a/cmd/yoke/main.go
+++ b/cmd/yoke/main.go
@@ -35,6 +35,10 @@ func main() {
 //go:embed cmd_help.txt
 var rootHelp string
 
+var CmdRoot = &YokeCommand{
+	Name: "yoke",
+}
+
 func init() {
 	rootHelp = strings.TrimSpace(internal.Colorize(rootHelp))
 }
@@ -51,6 +55,11 @@ func run() error {
 		fmt.Fprintln(flag.CommandLine.Output(), rootHelp)
 		flag.PrintDefaults()
 		fmt.Fprintln(os.Stderr)
+	}
+
+	if len(os.Args) > 0 && os.Args[1] == "complete" {
+		Complete()
+		return nil
 	}
 
 	flag.Parse()

--- a/cmd/yoke/main.go
+++ b/cmd/yoke/main.go
@@ -57,7 +57,7 @@ func run() error {
 		fmt.Fprintln(os.Stderr)
 	}
 
-	if len(os.Args) > 0 && os.Args[1] == "complete" {
+	if len(os.Args) > 1 && os.Args[1] == "complete" {
 		Complete()
 		return nil
 	}

--- a/cmd/yoke/main.go
+++ b/cmd/yoke/main.go
@@ -36,33 +36,33 @@ func main() {
 var rootHelp string
 
 var CmdRoot = &YokeCommand{
-	Name: "yoke",
+	Name:    "yoke",
+	FlagSet: flag.NewFlagSet("yoke", flag.ExitOnError),
+}
+
+var settings = GlobalSettings{
+	Debug: new(bool),
+	Kube:  genericclioptions.NewConfigFlags(false),
 }
 
 func init() {
 	rootHelp = strings.TrimSpace(internal.Colorize(rootHelp))
+	RegisterGlobalFlags(CmdRoot.FlagSet, &settings)
+	CmdRoot.FlagSet.Usage = func() {
+		fmt.Fprintln(flag.CommandLine.Output(), rootHelp)
+		CmdRoot.FlagSet.PrintDefaults()
+		fmt.Fprintln(os.Stderr)
+	}
 }
 
 func run() error {
-	settings := GlobalSettings{
-		Debug: new(bool),
-		Kube:  genericclioptions.NewConfigFlags(false),
-	}
-
-	RegisterGlobalFlags(flag.CommandLine, &settings)
-
-	flag.Usage = func() {
-		fmt.Fprintln(flag.CommandLine.Output(), rootHelp)
-		flag.PrintDefaults()
-		fmt.Fprintln(os.Stderr)
-	}
 
 	if len(os.Args) > 1 && os.Args[1] == "complete" {
 		Complete()
 		return nil
 	}
 
-	flag.Parse()
+	CmdRoot.FlagSet.Parse(os.Args)
 
 	ctx, cancel := xcontext.WithSignalCancelation(context.Background(), syscall.SIGINT)
 	defer cancel()
@@ -70,13 +70,13 @@ func run() error {
 	ctx = internal.WithDebugFlag(ctx, settings.Debug)
 
 	if len(flag.Args()) == 0 {
-		flag.Usage()
+		CmdRoot.FlagSet.Usage()
 		return fmt.Errorf("no command provided")
 	}
 
-	subcmdArgs := flag.Args()[1:]
+	subcmdArgs := CmdRoot.FlagSet.Args()[1:]
 
-	switch cmd := flag.Arg(0); cmd {
+	switch cmd := CmdRoot.FlagSet.Arg(0); cmd {
 	case "atc":
 		return ATC(ctx, GetAtcParams(settings, subcmdArgs))
 	case "takeoff", "up", "apply":

--- a/cmd/yoke/main.go
+++ b/cmd/yoke/main.go
@@ -6,12 +6,9 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"syscall"
-
-	"golang.org/x/term"
 
 	"github.com/davidmdm/x/xcontext"
 
@@ -19,7 +16,6 @@ import (
 
 	"github.com/yokecd/yoke/internal"
 	"github.com/yokecd/yoke/internal/home"
-	"github.com/yokecd/yoke/pkg/yoke"
 )
 
 func main() {
@@ -35,8 +31,41 @@ func main() {
 //go:embed cmd_help.txt
 var rootHelp string
 
+var CmdRoot = NewCommand("yoke", []string{}, func(ctx context.Context) (*flag.FlagSet, CmdRunner) {
+	flagset := flag.NewFlagSet("yoke", flag.ExitOnError)
+	flagset.Usage = func() {
+		rootHelp = strings.TrimSpace(internal.Colorize(rootHelp))
+		fmt.Fprintln(flag.CommandLine.Output(), rootHelp)
+		flagset.PrintDefaults()
+		fmt.Fprintln(os.Stderr)
+	}
+	runner := func(ctx context.Context, settings GlobalSettings, args []string) error {
+		RegisterGlobalFlags(flagset, &settings)
+		flagset.Parse(args)
+		if len(flagset.Args()) > 0 {
+			return fmt.Errorf("unknown command: %s", flagset.Arg(0))
+		}
+		if len(flagset.Args()) == 0 {
+			flagset.Usage()
+		}
+		return fmt.Errorf("no command provided")
+	}
+	return flagset, runner
+})
+
 func init() {
-	rootHelp = strings.TrimSpace(internal.Colorize(rootHelp))
+	CmdRoot.AddCommand(CmdATC)
+	CmdRoot.AddCommand(CmdBlackbox)
+	CmdRoot.AddCommand(CmdDescent)
+	CmdRoot.AddCommand(CmdMayday)
+	CmdRoot.AddCommand(CmdSchematics)
+	CmdRoot.AddCommand(CmdSign)
+	CmdRoot.AddCommand(CmdStow)
+	CmdRoot.AddCommand(CmdTakeoff)
+	CmdRoot.AddCommand(CmdTurbulence)
+	CmdRoot.AddCommand(CmdVersion)
+	CmdRoot.AddCommand(CmdUnlatch)
+	CmdRoot.AddCommand(CmdVerify)
 }
 
 func run() error {
@@ -45,120 +74,25 @@ func run() error {
 		Kube:  genericclioptions.NewConfigFlags(false),
 	}
 
-	RegisterGlobalFlags(flag.CommandLine, &settings)
-
-	flag.Usage = func() {
-		fmt.Fprintln(flag.CommandLine.Output(), rootHelp)
-		flag.PrintDefaults()
-		fmt.Fprintln(os.Stderr)
+	if len(os.Args) > 1 && os.Args[1] == "complete" {
+		Complete()
+		return nil
 	}
 
-	flag.Parse()
+	CmdRoot.FlagSet.Parse(os.Args)
 
 	ctx, cancel := xcontext.WithSignalCancelation(context.Background(), syscall.SIGINT)
 	defer cancel()
 
 	ctx = internal.WithDebugFlag(ctx, settings.Debug)
 
-	if len(flag.Args()) == 0 {
-		flag.Usage()
-		return fmt.Errorf("no command provided")
+	cmd, subCmdArgs := Seek(CmdRoot.FlagSet.Args())
+
+	if cmd == nil || cmd.Runner == nil {
+		return fmt.Errorf("unknown command")
 	}
 
-	subcmdArgs := flag.Args()[1:]
-
-	switch cmd := flag.Arg(0); cmd {
-	case "atc":
-		return ATC(ctx, GetAtcParams(settings, subcmdArgs))
-	case "takeoff", "up", "apply":
-		{
-			var source io.Reader
-			if !term.IsTerminal(int(os.Stdin.Fd())) {
-				source = os.Stdin
-			}
-			params, err := GetTakeoffParams(settings, source, subcmdArgs)
-			if err != nil {
-				return err
-			}
-			return TakeOff(ctx, *params)
-		}
-	case "descent", "down", "restore":
-		{
-			params, err := GetDescentfParams(settings, subcmdArgs)
-			if err != nil {
-				return err
-			}
-			return Descent(ctx, *params)
-		}
-	case "mayday", "delete":
-		{
-			params, err := GetMaydayParams(settings, subcmdArgs)
-			if err != nil {
-				return err
-			}
-			return Mayday(ctx, *params)
-		}
-	case "blackbox", "inspect":
-		{
-			params, err := GetBlackBoxParams(settings, subcmdArgs)
-			if err != nil {
-				return err
-			}
-			return Blackbox(ctx, *params)
-		}
-	case "turbulence", "drift", "diff":
-		{
-			params, err := GetTurbulenceParams(settings, subcmdArgs)
-			if err != nil {
-				return err
-			}
-			return Turbulence(ctx, *params)
-		}
-	case "stow", "push":
-		{
-			params, err := GetStowParams(subcmdArgs)
-			if err != nil {
-				return err
-			}
-			return yoke.Stow(ctx, *params)
-		}
-	case "unlatch", "unlock":
-		{
-			params, err := GetUnlatchParams(settings, subcmdArgs)
-			if err != nil {
-				return err
-			}
-			return Unlatch(ctx, *params)
-		}
-	case "schematics", "meta":
-		{
-			return SchematicsCommand(ctx, subcmdArgs)
-		}
-
-	case "sign":
-		{
-			params, err := GetSignParams(subcmdArgs)
-			if err != nil {
-				return err
-			}
-			return yoke.Sign(*params)
-		}
-	case "verify":
-		{
-			params, err := GetVerifyParams(subcmdArgs)
-			if err != nil {
-				return err
-			}
-			return yoke.Verify(*params)
-		}
-
-	case "version":
-		{
-			return Version(ctx)
-		}
-	default:
-		return fmt.Errorf("unknown command: %s", cmd)
-	}
+	return cmd.Runner(ctx, settings, subCmdArgs)
 }
 
 type GlobalSettings struct {

--- a/cmd/yoke/main_test.go
+++ b/cmd/yoke/main_test.go
@@ -56,14 +56,11 @@ func TestMain(m *testing.M) {
 }
 
 var (
-	settings = GlobalSettings{
-		Kube: func() *genericclioptions.ConfigFlags {
-			flags := genericclioptions.NewConfigFlags(false)
-			flags.KubeConfig = &home.Kubeconfig
-			return flags
-		}(),
-	}
 	background = internal.WithStdio(context.Background(), io.Discard, io.Discard, nil)
+	settings   = GlobalSettings{
+		Debug: new(bool),
+		Kube:  genericclioptions.NewConfigFlags(false),
+	}
 )
 
 func createBasicDeployment(t *testing.T, name, namespace string) io.Reader {

--- a/cmd/yoke/main_test.go
+++ b/cmd/yoke/main_test.go
@@ -56,13 +56,6 @@ func TestMain(m *testing.M) {
 }
 
 var (
-	settings = GlobalSettings{
-		Kube: func() *genericclioptions.ConfigFlags {
-			flags := genericclioptions.NewConfigFlags(false)
-			flags.KubeConfig = &home.Kubeconfig
-			return flags
-		}(),
-	}
 	background = internal.WithStdio(context.Background(), io.Discard, io.Discard, nil)
 )
 


### PR DESCRIPTION
# CLI Refactor
This PR overhauls the CLI command creation and parsing. Each command is now a struct, and exists in a command tree under the `CmdRoot` node. The `NewCommand` function now takes place of the previous `Get*Params` methods. The runner for each command does the work. 

# Completion
A step forward for #26.
We can now use the well structured tree & walk it to provide completions. Currently we just hard code the command map, but that should be replaced with using the `CmdRoot.SubCommands`. We only include the base commands in the completion, so we do not reach out to the Kubernetes API for any information.

## Quirks
- It is impossible to use a parents flag in a child command. We work around this in the `schematics` sub commands, but it's dubious. 
- We don't actually register global flags everywhere, I've matched the current main behavior.
- We don't register the completion function as a `YokeCommand`, this is because we want to go into the completions before calling `flag.Parse()`. 
- I've also opted to to not go embed the command_help. This is because it includes a `#`, which broke it. I'd like to keep that so that users can simply run `yoke complete >> ~/.bashrc`. 

## Future Work
- Completion per function i.e. `yoke blackbox <tab>` would yield a list of flights in the cluster
- Completion for global flags
- Figure out a better way to share flags between parent/children
- Completion for aliases

