### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/examples/embeddedfs/postgresql/values.yaml
+++ b/examples/embeddedfs/postgresql/values.yaml
@@ -1353,8 +1353,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/os-shell:12-debian-12-r16` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)